### PR TITLE
Add common configurations to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,22 @@ When you're ready to share your changes with the world, deploy your Next.js app 
 1. Run `firebase deploy` from the terminal.
 2. Check your website on: `SITE_ID.web.app` or `PROJECT_ID.web.app` (or your custom domain, if you did setup one)
 
+### Common Configurations
+
+#### Add `cleanUrls` option
+
+By default, a page created on `/pages/foo/bar.jsx` is only accessible through the url `/foo/bar.html`.
+To make the page accessible on `/foo/bar` instead, add `cleanUrls` option to your hosting config in firebase.json.
+
+```json
+{
+  "hosting": {
+    "source": ".",
+    "cleanUrls": true
+  }
+}
+```
+
 # Deploy Angular
 
 Easily deploy your Angular application to Firebase and serve dynamic content to your users.


### PR DESCRIPTION
In my next.js environment, after I created a page in `pages/foo/bar.tsx`, the page was only accessible through url `/foo/bar.html`.
I was able to access it through `/foo/bar` after adding `"cleanUrls": true` to my `firebase.json` hosting config.

my `next.config.js`:
```js
/** @type {import('next').NextConfig} */
const nextConfig = {
  reactStrictMode: true,
}

module.exports = nextConfig
```

my `package.json`:
```json
{
 "engines": {
    "node": "16"
  },
  "scripts": {
    "dev": "firebase emulators:start",
    "postinstall": "firebase --open-sesame frameworkawareness"
  },
  "dependencies": {
    "firebase": "^9.8.1",
    "firebase-admin": "^10.0.2",
    "firebase-functions": "^3.21.2",
    "firebase-tools": "^10.9.2",
    "next": "12.1.6"
  },
  "devDependencies": {
    "@types/react": "18.0.9",
    "@types/react-dom": "18.0.4",
    "firebase-functions-test": "^0.2.0",
    "typescript": "4.6.4"
  }
}
```