### PR TITLE
Add hostname and port to next custom server

### DIFF
--- a/src/next.js/index.ts
+++ b/src/next.js/index.ts
@@ -2,15 +2,37 @@ import { parse } from 'url';
 import { default as next } from 'next';
 import type { Request } from 'firebase-functions/v2/https';
 import type { Response } from 'express';
+import LRU from 'lru-cache';
+import { NextServer } from 'next/dist/server/next.js';
 
-const nextApp = next({
-    dev: false,
-    dir: process.cwd(),
+const nextAppsLRU = new LRU<string, NextServer>({
+    // TODO tune this
+    max: 3,
+    allowStale: true,
+    updateAgeOnGet: true,
+    dispose: (server) => {
+        server.close();
+    }
 });
-const nextAppPrepare = nextApp.prepare();
 
 export const handle = async (req: Request, res: Response) => {
-    const parsedUrl = parse(req.url, true);
-    await nextAppPrepare;
+    const { hostname, protocol, url } = req;
+    const port = protocol === 'https' ? 443 : 80;
+    const key = [hostname, port].join(':');
+    // I wish there was a better way to do this, but it seems like this is the
+    // way to go. Should investigate more if we can get hostname/port to be
+    // dynamic for middleware. 
+    let nextApp = nextAppsLRU.get(key);
+    if (!nextApp) {
+        nextApp = next({
+            dev: false,
+            dir: process.cwd(),
+            hostname,
+            port
+        });
+        nextAppsLRU.set(key, nextApp);
+    }
+    await nextApp.prepare();
+    const parsedUrl = parse(url, true);
     nextApp.getRequestHandler()(req, res, parsedUrl);
 };


### PR DESCRIPTION
Is there a way to do this that doesn't necessitate our spinning up multiple next instances?