### PR TITLE
Check token expiry instead of auth_time

### DIFF
--- a/src/firebase-aware.ts
+++ b/src/firebase-aware.ts
@@ -35,7 +35,7 @@ const mintCookie = async (req: Request, res: Response) => {
     const idToken = req.header('Authorization')?.split('Bearer ')?.[1];
     const verifiedIdToken = idToken ? await adminAuth.verifyIdToken(idToken) : null;
     if (verifiedIdToken) {
-        if (new Date().getTime() / 1_000 - verifiedIdToken.auth_time > ID_TOKEN_MAX_AGE) {
+        if (new Date().getTime() / 1_000 - verifiedIdToken.exp > ID_TOKEN_MAX_AGE) {
             res.status(301).end();
         } else {
             const cookie = await adminAuth.createSessionCookie(idToken!, { expiresIn: COOKIE_MAX_AGE }).catch((e: any) => {


### PR DESCRIPTION
I might be missing something, but checking `auth_time` always seems to return the first time the user authenticated, which means the token is always expired after 5 mins.