### PR TITLE
Fix `usingFirebaseJsSdk`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,8 +15,10 @@ type Server = typeof import('./angular/index.js') |
 import type { Request } from 'firebase-functions/v2/https';
 import type { Response } from 'express';
 
+import { isUsingFirebaseJsSdk } from './utils.js'
+
 const dirname = process.env.__FIREBASE_FRAMEWORKS_ENTRY__;
-const usingFirebaseJsSdk = !!process.env.__FIREBASE_DEFAULTS__;
+const usingFirebaseJsSdk = await isUsingFirebaseJsSdk();
 const basename = usingFirebaseJsSdk ? 'firebase-aware' : 'index';
 
 // .env isn't parsed for Cloud Functions discovery during deploy, handle undefined

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,11 @@
+export async function isUsingFirebaseJsSdk() {
+  if(!process.env.__FIREBASE_DEFAULTS__) return false;
+
+  try {
+    await import('firebase/app');
+
+    return true
+  } catch (e) {
+    return false;
+  }
+}


### PR DESCRIPTION
Apart from `process.env.__FIREBASE_DEFAULTS__`, check whether the Firebase JS SDK can be imported to assume that the app is using it. In some cases the env. variable was set even if the app was not using the Firebase JS SDK.

Fixes https://github.com/firebase/firebase-tools/issues/5996