### PR TITLE
add `--eslint` to create-next-app

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "build": "rimraf dist && tsc",
     "test": "npm run test:angular && npm run test:next && npm run test:nuxt && npm run test:nuxt3 && npm run test:custom",
-    "e2e:build-next": "rimraf e2e/next-test && cd e2e && npx create-next-app next-test --use-npm --ts && cd next-test && cp ../../tools/firebase.json . && cp ../../tools/.firebaserc .",
+    "e2e:build-next": "rimraf e2e/next-test && cd e2e && npx create-next-app next-test --use-npm --ts --eslint && cd next-test && cp ../../tools/firebase.json . && cp ../../tools/.firebaserc .",
     "e2e:build-vite": "rimraf e2e/vite-test && cd e2e && npx create-vite vite-test --template vue && cd vite-test && npm i && cp ../../tools/firebase.json . && cp ../../tools/.firebaserc .",
     "e2e:build-nuxt": "rimraf e2e/nuxt-test && cd e2e && npx create-nuxt-app nuxt-test --answers '$(cat ../tools/create-nuxt-answers.json)' && cd nuxt-test && cp ../../tools/firebase.json . && cp ../../tools/.firebaserc .",
     "e2e:build-nuxt3": "rimraf e2e/nuxt3-test && cd e2e && npx nuxi init nuxt3-test && cd nuxt3-test && npm i && cp ../../tools/firebase.json . && cp ../../tools/.firebaserc .",


### PR DESCRIPTION
This change makes `create-next-app` non-interactive by skipping the question `Would you like to use ESLint with this project?`