### PR TITLE
allow firebase sdk v10 in peer deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "node": "^16.0.0 || ^18.0.0"
       },
       "peerDependencies": {
-        "firebase": "^9.9.0",
+        "firebase": "^9.0.0 || ^10.0.0",
         "firebase-admin": "^11.0.1",
         "sharp": "^0.32.1"
       },

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "tslib": "^2.3.1"
   },
   "peerDependencies": {
-    "firebase": "^9.9.0",
+    "firebase": "^9.0.0 || ^10.0.0",
     "firebase-admin": "^11.0.1",
     "sharp": "^0.32.1"
   },


### PR DESCRIPTION
fixes https://github.com/firebase/firebase-tools/issues/6109

**Question:** After we cut a new release, I thought we might need to bump the [`FIREBASE_FRAMEWORKS_VERSION` constant](https://github.com/firebase/firebase-tools/blob/v12.4.3/src/frameworks/constants.ts#L28) in `firebase-tools`, but since it has the `^`, it should download the new `firebase-frameworks` version right? 