### PR TITLE
Apphosting dir fixes

### DIFF
--- a/packages/@apphosting/adapter-nextjs/src/bin/build.ts
+++ b/packages/@apphosting/adapter-nextjs/src/bin/build.ts
@@ -17,20 +17,18 @@ process.env.NEXT_TELEMETRY_DISABLED = "1";
 
 build(cwd);
 
-const {distDir} = await loadConfig(cwd);
+const { distDir } = await loadConfig(cwd);
 const manifest = await readRoutesManifest(join(cwd, distDir));
 
 const appHostingOutputDirectory = join(cwd, ".apphosting");
+const appHostingStaticDirectory = join(appHostingOutputDirectory, ".next", "static");
 const appHostingPublicDirectory = join(appHostingOutputDirectory, "public");
-const nextStaticAssetsDestination = join(appHostingPublicDirectory, manifest.basePath, "_next", "static");
 const outputBundlePath = join(appHostingOutputDirectory, "bundle.yaml");
 const serverFilePath = join(appHostingOutputDirectory, "server.js");
 
 const standaloneDirectory = join(cwd, distDir, "standalone");
 const staticDirectory = join(cwd, distDir, "static");
 const publicDirectory = join(cwd, "public");
-
-await mkdirp(nextStaticAssetsDestination);
 
 // Run build command
 function build(cwd: string) {
@@ -41,8 +39,7 @@ function build(cwd: string) {
 const movePublicDirectory = async () => {
     const publicDirectoryExists = await exists(publicDirectory);
     if (!publicDirectoryExists) return;
-    await move(publicDirectory, join(appHostingPublicDirectory, manifest.basePath), { overwrite: true });
-    await move(staticDirectory, nextStaticAssetsDestination, { overwrite: true })
+    await move(publicDirectory, appHostingPublicDirectory, { overwrite: true });
 };
   
 // generate bundle.yaml
@@ -65,6 +62,7 @@ const generateBundleYaml = async () => {
 // as well as generating bundle.yaml
 await move(standaloneDirectory, appHostingOutputDirectory, { overwrite: true });
 await Promise.all([
+    await move(staticDirectory, appHostingStaticDirectory, { overwrite: true }),
     movePublicDirectory(),
     generateBundleYaml(),
 ]);

--- a/packages/@apphosting/adapter-nextjs/src/bin/build.ts
+++ b/packages/@apphosting/adapter-nextjs/src/bin/build.ts
@@ -63,7 +63,7 @@ const generateBundleYaml = async () => {
 // as well as generating bundle.yaml
 await move(standaloneDirectory, appHostingOutputDirectory, { overwrite: true });
 await Promise.all([
-    await move(staticDirectory, appHostingStaticDirectory, { overwrite: true }),
+    move(staticDirectory, appHostingStaticDirectory, { overwrite: true }),
     movePublicDirectory(),
     generateBundleYaml(),
 ]);

--- a/packages/@apphosting/adapter-nextjs/src/bin/build.ts
+++ b/packages/@apphosting/adapter-nextjs/src/bin/build.ts
@@ -2,7 +2,7 @@
 import { spawnSync } from "child_process";
 import { loadConfig, readRoutesManifest } from "../utils.js";
 
-import { join, relative } from "path";
+import { join, relative, dirname, normalize } from "path";
 import fsExtra from "fs-extra";
 import { stringify as yamlStringify } from "yaml";
 
@@ -48,13 +48,14 @@ const generateBundleYaml = async () => {
     const redirects = manifest.redirects.filter(it => !it.internal).map(it => ({...it, regex: undefined}));
     const beforeFileRewrites = Array.isArray(manifest.rewrites) ? manifest.rewrites : manifest.rewrites?.beforeFiles || [];
     const rewrites = beforeFileRewrites.map(it => ({...it, regex: undefined}));
+    const outputBundleDirectory = dirname(outputBundlePath);
     await writeFile(outputBundlePath, yamlStringify({
         headers, 
         redirects, 
         rewrites,
-        runCommand: `node ${relative(appHostingOutputDirectory, serverFilePath)}`,
-        neededDirs: ["."],
-        staticAssets: [relative(appHostingOutputDirectory, appHostingPublicDirectory)],
+        runCommand: `node ${normalize(relative(outputBundleDirectory, serverFilePath))}`,
+        neededDirs: [normalize(relative(outputBundleDirectory, appHostingOutputDirectory))],
+        staticAssets: [normalize(relative(outputBundleDirectory, appHostingPublicDirectory))],
     }));
 }
 


### PR DESCRIPTION
* For standalone and no CDN static directory should be placed in .next ([see docs here](https://nextjs.org/docs/pages/api-reference/next-config-js/output#automatically-copying-traced-files))
* Public dir existence check was looking at the wrong spot
* Use relative directories in the bundle.yaml
* Fix the race conditions in the folder moving which were wiping files out