### PR TITLE
Bump ff version

### DIFF
--- a/packages/firebase-frameworks/package.json
+++ b/packages/firebase-frameworks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firebase-frameworks",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "Experimental addon to the Firebase CLI to add web framework support",
   "main": "dist/index.js",
   "repository": {


### PR DESCRIPTION
v0.11.2 was not released in Github Actions due to the package.json version being out of date, i need to make this failure more obvious. Will allow https://github.com/firebase/firebase-tools/issues/6688 to be fixed