### PR TITLE
lockdown publish branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
         run: npm ci
       - name: Build
         run: npm run build
-      - name: 'Upload Artifact'
+      - name: "Upload Artifact"
         uses: actions/upload-artifact@v3
         with:
           path: |
@@ -57,7 +57,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        node: [ 16, 18, 20 ]
+        node: [16, 18, 20]
       fail-fast: false
     name: Test Node ${{ matrix.node }}
     steps:
@@ -124,28 +124,28 @@ jobs:
   test_and_contribute:
     runs-on: ubuntu-latest
     name: Branch protection
-    needs: ['test', 'lint']
+    needs: ["test", "lint"]
     steps:
       - run: true
 
   publish:
     runs-on: ubuntu-latest
     name: Publish (NPM)
-    needs: ['build', 'test']
+    needs: ["build", "test"]
     if: ${{ github.ref == 'refs/heads/main' || github.event_name == 'release' }}
     permissions:
       id-token: write
     steps:
       - uses: actions/checkout@v4
         with:
-            fetch-depth: 2
+          fetch-depth: 2
       - name: Setup node
         uses: actions/setup-node@v3
         with:
           node-version: 20
           check-latest: false
-          registry-url: 'https://registry.npmjs.org'
-      - name: 'Download Artifacts'
+          registry-url: "https://registry.npmjs.org"
+      - name: "Download Artifacts"
         uses: actions/download-artifact@v3
       - name: Rsync Artifacts
         run: rsync -a artifact/ packages
@@ -155,3 +155,4 @@ jobs:
           # ADAPTER_NEXTJS_NPM_TOKEN: ${{ secrets.ADAPTER_NEXTJS_NPM_TOKEN }}
           # FIREBASE_FRAMEWORKS_NPM_TOKEN: ${{ secrets.FIREBASE_FRAMEWORKS_NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.PERSONAL_NPM_TOKEN }}
+          BRANCH_NAME: ${{ github.event.base_ref }}

--- a/scripts/github.js
+++ b/scripts/github.js
@@ -5,6 +5,9 @@ const { basename } = require("path");
 const [, packageFromRef, versionFromRef, , prerelease] =
   /^refs\/tags\/(.+)-v(\d\d*\.\d\d*(\.\d\d*)?(-.+)?)$/.exec(process.env.GITHUB_REF ?? "") ?? [];
 
+const [, packageFromBranch, versionFromBranch] =
+  /^refs\/heads\/(.+)-v(\d\d*\.\d\d*)$/.exec(process.env.BRANCH_NAME ?? "") ?? [];
+
 const since = process.env.GITHUB_ACTION
   ? `--since ${
       (process.env.GITHUB_BASE_REF && `origin/${process.env.GITHUB_BASE_REF}`) || "HEAD^1"
@@ -39,4 +42,6 @@ module.exports = {
   filteredLernaList,
   shortSHA,
   lernaScopeArgs,
+  packageFromBranch,
+  versionFromBranch,
 };

--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -1,8 +1,17 @@
 #! /usr/bin/env node
 const { execSync } = require("child_process");
+const { minor, major } = require("semver");
 const { writeFileSync, readFileSync } = require("fs");
 const { join } = require("path");
-const { filteredLernaList, versionFromRef, shortSHA, prerelease } = require("./github.js");
+const {
+  filteredLernaList,
+  versionFromRef,
+  shortSHA,
+  prerelease,
+  packageFromBranch,
+  versionFromBranch,
+  packageFromRef,
+} = require("./github.js");
 
 const wombatDressingRoomTokens = new Map([
   // Disabling this until I can get wombat access to this org
@@ -20,6 +29,20 @@ for (const lerna of filteredLernaList) {
   if (versionFromRef && versionFromRef.split("-")[0] !== lerna.version) {
     throw new Error(
       `Cowardly refusing to publish ${lerna.name}@${versionFromRef} from ${lerna.version}, version needs to be bumped in source.`,
+    );
+  }
+  if (
+    versionFromRef &&
+    packageFromRef &&
+    (packageFromRef !== packageFromBranch ||
+      `${major(versionFromRef)}.${minor(versionFromRef)}` !== versionFromBranch)
+  ) {
+    throw new Error(
+      `Refusing to publish ${lerna.name}@${versionFromRef}, ${
+        lerna.name
+      }@${versionFromRef} needs to be published from the branch: ${packageFromRef}-v${major(
+        versionFromRef,
+      )}.${minor(versionFromRef)}`,
     );
   }
   const version = versionFromRef || `${lerna.version}-canary.${shortSHA}`;


### PR DESCRIPTION
Adds additional logic in publishing flow so that releases to the build adapter can only be published from the appropriate branch. For example adapter-nextjs-v14.0.1 can only be released from the adapter-nextjs-v14.0 branch