### PR TITLE
Support monorepo builds in Angular adapter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,12 +48,12 @@
       }
     },
     "node_modules/@angular-devkit/architect": {
-      "version": "0.1700.7",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1700.7.tgz",
-      "integrity": "sha512-32uitQKsYLGXAKoXBsmOnPsTt9pS+b9cnFI9ZvBFVhJ31I2EOM7vGcMFalhTxdB/DkVHk4TyO78efV0V26DwCA==",
+      "version": "0.1702.3",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1702.3.tgz",
+      "integrity": "sha512-4jeBgtBIZxAeJyiwSdbRE4+rWu34j0UMCKia8s7473rKj0Tn4+dXlHmA/kuFYIp6K/9pE/hBoeUFxLNA/DZuRQ==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "17.0.7",
+        "@angular-devkit/core": "17.2.3",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -1115,15 +1115,15 @@
       }
     },
     "node_modules/@angular-devkit/core": {
-      "version": "17.0.7",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-17.0.7.tgz",
-      "integrity": "sha512-vATobHo5O5tJba424hJfQWLb40GzvZPNsI74dcgSUTgrDph8ksmk5xB9OvEvf0INorQZ2IMphj/VIWj4/+JqSA==",
+      "version": "17.2.3",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-17.2.3.tgz",
+      "integrity": "sha512-A7WWl1/VsZw6utFFPBib1wSbAB5OeBgAgQmVpVe9wW8u9UZa6CLc7b3InWtRRyBXTo9Sa5GNZDFfwlXhy3iW3w==",
       "dev": true,
       "dependencies": {
         "ajv": "8.12.0",
         "ajv-formats": "2.1.1",
-        "jsonc-parser": "3.2.0",
-        "picomatch": "3.0.1",
+        "jsonc-parser": "3.2.1",
+        "picomatch": "4.0.1",
         "rxjs": "7.8.1",
         "source-map": "0.7.4"
       },
@@ -1163,13 +1163,19 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true
     },
+    "node_modules/@angular-devkit/core/node_modules/jsonc-parser": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.1.tgz",
+      "integrity": "sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA==",
+      "dev": true
+    },
     "node_modules/@angular-devkit/core/node_modules/picomatch": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-3.0.1.tgz",
-      "integrity": "sha512-I3EurrIQMlRc9IaAZnqRR044Phh2DXY+55o7uJ0V+hYZAcQYSuFWsc9q5PvyDHUSCe1Qxn/iBz+78s86zWnGag==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.1.tgz",
+      "integrity": "sha512-xUXwsxNjwTQ8K3GnT4pCJm+xq3RUPQbmkYJTP5aFIfNIvbcc/4MUxgBaaRSZJ6yGJZiGSyYlM6MzwTsRk8SYCg==",
       "dev": true,
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
@@ -22876,9 +22882,9 @@
         "apphosting-adapter-angular-create": "dist/bin/create.js"
       },
       "devDependencies": {
-        "@angular-devkit/architect": "~0.1700.0",
-        "@angular-devkit/core": "~17.0.0",
-        "@angular/core": "~17.0.0",
+        "@angular-devkit/architect": "~0.1702.0",
+        "@angular-devkit/core": "~17.2.0",
+        "@angular/core": "~17.2.0",
         "@types/fs-extra": "*",
         "@types/mocha": "*",
         "@types/tmp": "*",
@@ -22890,8 +22896,8 @@
         "typescript": "*"
       },
       "peerDependencies": {
-        "@angular-devkit/architect": "~0.1700.0",
-        "@angular-devkit/core": "~17.0.0"
+        "@angular-devkit/architect": "~0.1702.0",
+        "@angular-devkit/core": "~17.2.0"
       },
       "peerDependenciesMeta": {
         "@angular-devkit/architect": {
@@ -22903,9 +22909,9 @@
       }
     },
     "packages/@apphosting/adapter-angular/node_modules/@angular/core": {
-      "version": "17.0.9",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-17.0.9.tgz",
-      "integrity": "sha512-LtDWzyx19XNmAjXju9xjw//rDZPUFu2bllHqzS6NVO1bE4PwJHIs0zfvygh0j46ubKp1gUICNk3jvYK9FMVinA==",
+      "version": "17.2.4",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-17.2.4.tgz",
+      "integrity": "sha512-5Bko+vk7H1Ce57MHuRcpZtq2Srq5euufSvwg0piPozp0yYmCqNoYN7c128kgi6PbiPQeAnKRzRbEuYd1YCU4Tw==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -22918,6 +22924,162 @@
         "zone.js": "~0.14.0"
       }
     },
+    "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.12.0.tgz",
+      "integrity": "sha512-+ac02NL/2TCKRrJu2wffk1kZ+RyqxVUlbjSagNgPm94frxtr+XDL12E5Ll1enWskLrtrZ2r8L3wED1orIibV/w==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.12.0.tgz",
+      "integrity": "sha512-OBqcX2BMe6nvjQ0Nyp7cC90cnumt8PXmO7Dp3gfAju/6YwG0Tj74z1vKrfRz7qAv23nBcYM8BCbhrsWqO7PzQQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.12.0.tgz",
+      "integrity": "sha512-X64tZd8dRE/QTrBIEs63kaOBG0b5GVEd3ccoLtyf6IdXtHdh8h+I56C2yC3PtC9Ucnv0CpNFJLqKFVgCYe0lOQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.12.0.tgz",
+      "integrity": "sha512-cc71KUZoVbUJmGP2cOuiZ9HSOP14AzBAThn3OU+9LcA1+IUqswJyR1cAJj3Mg55HbjZP6OLAIscbQsQLrpgTOg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.12.0.tgz",
+      "integrity": "sha512-a6w/Y3hyyO6GlpKL2xJ4IOh/7d+APaqLYdMf86xnczU3nurFTaVN9s9jOXQg97BE4nYm/7Ga51rjec5nfRdrvA==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.12.0.tgz",
+      "integrity": "sha512-0fZBq27b+D7Ar5CQMofVN8sggOVhEtzFUwOwPppQt0k+VR+7UHMZZY4y+64WJ06XOhBTKXtQB/Sv0NwQMXyNAA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.12.0.tgz",
+      "integrity": "sha512-eTvzUS3hhhlgeAv6bfigekzWZjaEX9xP9HhxB0Dvrdbkk5w/b+1Sxct2ZuDxNJKzsRStSq1EaEkVSEe7A7ipgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.12.0.tgz",
+      "integrity": "sha512-ix+qAB9qmrCRiaO71VFfY8rkiAZJL8zQRXveS27HS+pKdjwUfEhqo2+YF2oI+H/22Xsiski+qqwIBxVewLK7sw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.12.0.tgz",
+      "integrity": "sha512-TenQhZVOtw/3qKOPa7d+QgkeM6xY0LtwzR8OplmyL5LrgTWIXpTQg2Q2ycBf8jm+SFW2Wt/DTn1gf7nFp3ssVA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.12.0.tgz",
+      "integrity": "sha512-LfFdRhNnW0zdMvdCb5FNuWlls2WbbSridJvxOvYWgSBOYZtgBfW9UGNJG//rwMqTX1xQE9BAodvMH9tAusKDUw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.12.0.tgz",
+      "integrity": "sha512-JPDxovheWNp6d7AHCgsUlkuCKvtu3RB55iNEkaQcf0ttsDU/JZF+iQnYcQJSk/7PtT4mjjVG8N1kpwnI9SLYaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.12.0.tgz",
+      "integrity": "sha512-fjtuvMWRGJn1oZacG8IPnzIV6GF2/XG+h71FKn76OYFqySXInJtseAqdprVTDTyqPxQOG9Exak5/E9Z3+EJ8ZA==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.12.0.tgz",
+      "integrity": "sha512-ZYmr5mS2wd4Dew/JjT0Fqi2NPB/ZhZ2VvPp7SmvPZb4Y1CG/LRcS6tcRo2cYU7zLK5A7cdbhWnnWmUjoI4qapg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "packages/@apphosting/adapter-angular/node_modules/ansi-regex": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
@@ -22927,6 +23089,37 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "packages/@apphosting/adapter-angular/node_modules/rollup": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.12.0.tgz",
+      "integrity": "sha512-wz66wn4t1OHIJw3+XU7mJJQV/2NAfw5OAk6G6Hoo3zcvz/XOfQ52Vgi+AN4Uxoxi0KBBwk2g8zPrTDA4btSB/Q==",
+      "dependencies": {
+        "@types/estree": "1.0.5"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.12.0",
+        "@rollup/rollup-android-arm64": "4.12.0",
+        "@rollup/rollup-darwin-arm64": "4.12.0",
+        "@rollup/rollup-darwin-x64": "4.12.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.12.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.12.0",
+        "@rollup/rollup-linux-arm64-musl": "4.12.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.12.0",
+        "@rollup/rollup-linux-x64-gnu": "4.12.0",
+        "@rollup/rollup-linux-x64-musl": "4.12.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.12.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.12.0",
+        "@rollup/rollup-win32-x64-msvc": "4.12.0",
+        "fsevents": "~2.3.2"
       }
     },
     "packages/@apphosting/adapter-angular/node_modules/strip-ansi": {
@@ -22941,444 +23134,257 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "packages/@apphosting/adapter-angular/src/simple-server": {
+      "dependencies": {
+        "@rollup/plugin-json": "^6.1.0",
+        "express": "^4.18.2",
+        "rollup": "^4.12.0"
       },
-      "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-android-arm-eabi": {
-        "version": "4.12.0",
-        "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.12.0.tgz",
-        "integrity": "sha512-+ac02NL/2TCKRrJu2wffk1kZ+RyqxVUlbjSagNgPm94frxtr+XDL12E5Ll1enWskLrtrZ2r8L3wED1orIibV/w==",
-        "cpu": [
-          "arm"
-        ],
-        "optional": true,
-        "os": [
-          "android"
-        ]
+      "devDependencies": {
+        "@rollup/plugin-node-resolve": "^15.2.3",
+        "rollup-plugin-commonjs": "^10.1.0",
+        "rollup-plugin-node-resolve": "^5.2.0"
+      }
+    },
+    "packages/@apphosting/adapter-nextjs": {
+      "version": "14.0.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "fs-extra": "^11.1.1",
+        "yaml": "^2.3.4"
       },
-      "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-android-arm64": {
-        "version": "4.12.0",
-        "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.12.0.tgz",
-        "integrity": "sha512-OBqcX2BMe6nvjQ0Nyp7cC90cnumt8PXmO7Dp3gfAju/6YwG0Tj74z1vKrfRz7qAv23nBcYM8BCbhrsWqO7PzQQ==",
-        "cpu": [
-          "arm64"
-        ],
-        "optional": true,
-        "os": [
-          "android"
-        ]
+      "bin": {
+        "apphosting-adapter-nextjs-build": "dist/bin/build.js",
+        "apphosting-adapter-nextjs-create": "dist/bin/create.js"
       },
-      "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-darwin-arm64": {
-        "version": "4.12.0",
-        "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.12.0.tgz",
-        "integrity": "sha512-X64tZd8dRE/QTrBIEs63kaOBG0b5GVEd3ccoLtyf6IdXtHdh8h+I56C2yC3PtC9Ucnv0CpNFJLqKFVgCYe0lOQ==",
-        "cpu": [
-          "arm64"
-        ],
-        "optional": true,
-        "os": [
-          "darwin"
-        ]
+      "devDependencies": {
+        "@types/fs-extra": "*",
+        "@types/tmp": "*",
+        "next": "~14.0.0",
+        "semver": "*",
+        "tmp": "*",
+        "ts-node": "*"
       },
-      "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-darwin-x64": {
-        "version": "4.12.0",
-        "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.12.0.tgz",
-        "integrity": "sha512-cc71KUZoVbUJmGP2cOuiZ9HSOP14AzBAThn3OU+9LcA1+IUqswJyR1cAJj3Mg55HbjZP6OLAIscbQsQLrpgTOg==",
-        "cpu": [
-          "x64"
-        ],
-        "optional": true,
-        "os": [
-          "darwin"
-        ]
+      "peerDependencies": {
+        "next": "~14.0.0"
       },
-      "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-        "version": "4.12.0",
-        "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.12.0.tgz",
-        "integrity": "sha512-a6w/Y3hyyO6GlpKL2xJ4IOh/7d+APaqLYdMf86xnczU3nurFTaVN9s9jOXQg97BE4nYm/7Ga51rjec5nfRdrvA==",
-        "cpu": [
-          "arm"
-        ],
-        "optional": true,
-        "os": [
-          "linux"
-        ]
-      },
-      "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-linux-arm64-gnu": {
-        "version": "4.12.0",
-        "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.12.0.tgz",
-        "integrity": "sha512-0fZBq27b+D7Ar5CQMofVN8sggOVhEtzFUwOwPppQt0k+VR+7UHMZZY4y+64WJ06XOhBTKXtQB/Sv0NwQMXyNAA==",
-        "cpu": [
-          "arm64"
-        ],
-        "optional": true,
-        "os": [
-          "linux"
-        ]
-      },
-      "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-linux-arm64-musl": {
-        "version": "4.12.0",
-        "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.12.0.tgz",
-        "integrity": "sha512-eTvzUS3hhhlgeAv6bfigekzWZjaEX9xP9HhxB0Dvrdbkk5w/b+1Sxct2ZuDxNJKzsRStSq1EaEkVSEe7A7ipgQ==",
-        "cpu": [
-          "arm64"
-        ],
-        "optional": true,
-        "os": [
-          "linux"
-        ]
-      },
-      "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-linux-riscv64-gnu": {
-        "version": "4.12.0",
-        "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.12.0.tgz",
-        "integrity": "sha512-ix+qAB9qmrCRiaO71VFfY8rkiAZJL8zQRXveS27HS+pKdjwUfEhqo2+YF2oI+H/22Xsiski+qqwIBxVewLK7sw==",
-        "cpu": [
-          "riscv64"
-        ],
-        "optional": true,
-        "os": [
-          "linux"
-        ]
-      },
-      "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-linux-x64-gnu": {
-        "version": "4.12.0",
-        "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.12.0.tgz",
-        "integrity": "sha512-TenQhZVOtw/3qKOPa7d+QgkeM6xY0LtwzR8OplmyL5LrgTWIXpTQg2Q2ycBf8jm+SFW2Wt/DTn1gf7nFp3ssVA==",
-        "cpu": [
-          "x64"
-        ],
-        "optional": true,
-        "os": [
-          "linux"
-        ]
-      },
-      "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-linux-x64-musl": {
-        "version": "4.12.0",
-        "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.12.0.tgz",
-        "integrity": "sha512-LfFdRhNnW0zdMvdCb5FNuWlls2WbbSridJvxOvYWgSBOYZtgBfW9UGNJG//rwMqTX1xQE9BAodvMH9tAusKDUw==",
-        "cpu": [
-          "x64"
-        ],
-        "optional": true,
-        "os": [
-          "linux"
-        ]
-      },
-      "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-win32-arm64-msvc": {
-        "version": "4.12.0",
-        "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.12.0.tgz",
-        "integrity": "sha512-JPDxovheWNp6d7AHCgsUlkuCKvtu3RB55iNEkaQcf0ttsDU/JZF+iQnYcQJSk/7PtT4mjjVG8N1kpwnI9SLYaw==",
-        "cpu": [
-          "arm64"
-        ],
-        "optional": true,
-        "os": [
-          "win32"
-        ]
-      },
-      "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-win32-ia32-msvc": {
-        "version": "4.12.0",
-        "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.12.0.tgz",
-        "integrity": "sha512-fjtuvMWRGJn1oZacG8IPnzIV6GF2/XG+h71FKn76OYFqySXInJtseAqdprVTDTyqPxQOG9Exak5/E9Z3+EJ8ZA==",
-        "cpu": [
-          "ia32"
-        ],
-        "optional": true,
-        "os": [
-          "win32"
-        ]
-      },
-      "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-win32-x64-msvc": {
-        "version": "4.12.0",
-        "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.12.0.tgz",
-        "integrity": "sha512-ZYmr5mS2wd4Dew/JjT0Fqi2NPB/ZhZ2VvPp7SmvPZb4Y1CG/LRcS6tcRo2cYU7zLK5A7cdbhWnnWmUjoI4qapg==",
-        "cpu": [
-          "x64"
-        ],
-        "optional": true,
-        "os": [
-          "win32"
-        ]
-      },
-      "packages/@apphosting/adapter-angular/node_modules/rollup": {
-        "version": "4.12.0",
-        "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.12.0.tgz",
-        "integrity": "sha512-wz66wn4t1OHIJw3+XU7mJJQV/2NAfw5OAk6G6Hoo3zcvz/XOfQ52Vgi+AN4Uxoxi0KBBwk2g8zPrTDA4btSB/Q==",
-        "dependencies": {
-          "@types/estree": "1.0.5"
-        },
-        "bin": {
-          "rollup": "dist/bin/rollup"
-        },
-        "engines": {
-          "node": ">=18.0.0",
-          "npm": ">=8.0.0"
-        },
-        "optionalDependencies": {
-          "@rollup/rollup-android-arm-eabi": "4.12.0",
-          "@rollup/rollup-android-arm64": "4.12.0",
-          "@rollup/rollup-darwin-arm64": "4.12.0",
-          "@rollup/rollup-darwin-x64": "4.12.0",
-          "@rollup/rollup-linux-arm-gnueabihf": "4.12.0",
-          "@rollup/rollup-linux-arm64-gnu": "4.12.0",
-          "@rollup/rollup-linux-arm64-musl": "4.12.0",
-          "@rollup/rollup-linux-riscv64-gnu": "4.12.0",
-          "@rollup/rollup-linux-x64-gnu": "4.12.0",
-          "@rollup/rollup-linux-x64-musl": "4.12.0",
-          "@rollup/rollup-win32-arm64-msvc": "4.12.0",
-          "@rollup/rollup-win32-ia32-msvc": "4.12.0",
-          "@rollup/rollup-win32-x64-msvc": "4.12.0",
-          "fsevents": "~2.3.2"
+      "peerDependenciesMeta": {
+        "next": {
+          "optional": true
         }
+      }
+    },
+    "packages/@apphosting/build": {
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@apphosting/discover": "*",
+        "colorette": "^2.0.20",
+        "commander": "^11.1.0",
+        "npm-pick-manifest": "^9.0.0",
+        "ts-node": "^10.9.1"
       },
-      "packages/@apphosting/adapter-angular/src/simple-server": {
-        "dependencies": {
-          "@rollup/plugin-json": "^6.1.0",
-          "express": "^4.18.2",
-          "rollup": "^4.12.0"
-        },
-        "devDependencies": {
-          "@rollup/plugin-node-resolve": "^15.2.3",
-          "rollup-plugin-commonjs": "^10.1.0",
-          "rollup-plugin-node-resolve": "^5.2.0"
-        }
+      "bin": {
+        "build": "dist/bin/build.js"
       },
-      "packages/@apphosting/adapter-nextjs": {
-        "version": "14.0.0",
-        "license": "Apache-2.0",
-        "dependencies": {
-          "fs-extra": "^11.1.1",
-          "yaml": "^2.3.4"
-        },
-        "bin": {
-          "apphosting-adapter-nextjs-build": "dist/bin/build.js",
-          "apphosting-adapter-nextjs-create": "dist/bin/create.js"
-        },
-        "devDependencies": {
-          "@types/fs-extra": "*",
-          "@types/tmp": "*",
-          "next": "~14.0.0",
-          "semver": "*",
-          "tmp": "*",
-          "ts-node": "*"
-        },
-        "peerDependencies": {
-          "next": "~14.0.0"
-        },
-        "peerDependenciesMeta": {
-          "next": {
-            "optional": true
-          }
-        }
+      "devDependencies": {
+        "@types/commander": "*"
+      }
+    },
+    "packages/@apphosting/build/node_modules/hosted-git-info": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.1.tgz",
+      "integrity": "sha512-+K84LB1DYwMHoHSgaOY/Jfhw3ucPmSET5v98Ke/HdNSw4a0UktWzyW1mjhjpuxxTqOOsfWT/7iVshHmVZ4IpOA==",
+      "dependencies": {
+        "lru-cache": "^10.0.1"
       },
-      "packages/@apphosting/build": {
-        "version": "0.1.0",
-        "license": "Apache-2.0",
-        "dependencies": {
-          "@apphosting/discover": "*",
-          "colorette": "^2.0.20",
-          "commander": "^11.1.0",
-          "npm-pick-manifest": "^9.0.0",
-          "ts-node": "^10.9.1"
-        },
-        "bin": {
-          "build": "dist/bin/build.js"
-        },
-        "devDependencies": {
-          "@types/commander": "*"
-        }
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "packages/@apphosting/build/node_modules/lru-cache": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.1.0.tgz",
+      "integrity": "sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==",
+      "engines": {
+        "node": "14 || >=16.14"
+      }
+    },
+    "packages/@apphosting/build/node_modules/npm-normalize-package-bin": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-3.0.1.tgz",
+      "integrity": "sha512-dMxCf+zZ+3zeQZXKxmyuCKlIDPGuv8EF940xbkC4kQVDTtqoh6rJFO+JTKSA6/Rwi0getWmtuy4Itup0AMcaDQ==",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "packages/@apphosting/build/node_modules/npm-package-arg": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-11.0.1.tgz",
+      "integrity": "sha512-M7s1BD4NxdAvBKUPqqRW957Xwcl/4Zvo8Aj+ANrzvIPzGJZElrH7Z//rSaec2ORcND6FHHLnZeY8qgTpXDMFQQ==",
+      "dependencies": {
+        "hosted-git-info": "^7.0.0",
+        "proc-log": "^3.0.0",
+        "semver": "^7.3.5",
+        "validate-npm-package-name": "^5.0.0"
       },
-      "packages/@apphosting/build/node_modules/hosted-git-info": {
-        "version": "7.0.1",
-        "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.1.tgz",
-        "integrity": "sha512-+K84LB1DYwMHoHSgaOY/Jfhw3ucPmSET5v98Ke/HdNSw4a0UktWzyW1mjhjpuxxTqOOsfWT/7iVshHmVZ4IpOA==",
-        "dependencies": {
-          "lru-cache": "^10.0.1"
-        },
-        "engines": {
-          "node": "^16.14.0 || >=18.0.0"
-        }
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "packages/@apphosting/build/node_modules/npm-pick-manifest": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-9.0.0.tgz",
+      "integrity": "sha512-VfvRSs/b6n9ol4Qb+bDwNGUXutpy76x6MARw/XssevE0TnctIKcmklJZM5Z7nqs5z5aW+0S63pgCNbpkUNNXBg==",
+      "dependencies": {
+        "npm-install-checks": "^6.0.0",
+        "npm-normalize-package-bin": "^3.0.0",
+        "npm-package-arg": "^11.0.0",
+        "semver": "^7.3.5"
       },
-      "packages/@apphosting/build/node_modules/lru-cache": {
-        "version": "10.1.0",
-        "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.1.0.tgz",
-        "integrity": "sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==",
-        "engines": {
-          "node": "14 || >=16.14"
-        }
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "packages/@apphosting/create": {
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "commander": "^11.1.0",
+        "semver": "^7.5.4"
       },
-      "packages/@apphosting/build/node_modules/npm-normalize-package-bin": {
-        "version": "3.0.1",
-        "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-3.0.1.tgz",
-        "integrity": "sha512-dMxCf+zZ+3zeQZXKxmyuCKlIDPGuv8EF940xbkC4kQVDTtqoh6rJFO+JTKSA6/Rwi0getWmtuy4Itup0AMcaDQ==",
-        "engines": {
-          "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-        }
+      "bin": {
+        "create": "dist/bin/create.js"
       },
-      "packages/@apphosting/build/node_modules/npm-package-arg": {
-        "version": "11.0.1",
-        "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-11.0.1.tgz",
-        "integrity": "sha512-M7s1BD4NxdAvBKUPqqRW957Xwcl/4Zvo8Aj+ANrzvIPzGJZElrH7Z//rSaec2ORcND6FHHLnZeY8qgTpXDMFQQ==",
-        "dependencies": {
-          "hosted-git-info": "^7.0.0",
-          "proc-log": "^3.0.0",
-          "semver": "^7.3.5",
-          "validate-npm-package-name": "^5.0.0"
-        },
-        "engines": {
-          "node": "^16.14.0 || >=18.0.0"
-        }
+      "devDependencies": {
+        "@types/commander": "*",
+        "ts-node": "*"
+      }
+    },
+    "packages/@apphosting/discover": {
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@npmcli/arborist": "^7.2.1",
+        "@yarnpkg/lockfile": "^1.1.0",
+        "colorette": "^2.0.20",
+        "commander": "^11.1.0",
+        "fs-extra": "^11.1.1",
+        "npm-pick-manifest": "^9.0.0",
+        "toml": "^3.0.0",
+        "ts-node": "^10.9.1",
+        "yaml": "^2.3.4"
       },
-      "packages/@apphosting/build/node_modules/npm-pick-manifest": {
-        "version": "9.0.0",
-        "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-9.0.0.tgz",
-        "integrity": "sha512-VfvRSs/b6n9ol4Qb+bDwNGUXutpy76x6MARw/XssevE0TnctIKcmklJZM5Z7nqs5z5aW+0S63pgCNbpkUNNXBg==",
-        "dependencies": {
-          "npm-install-checks": "^6.0.0",
-          "npm-normalize-package-bin": "^3.0.0",
-          "npm-package-arg": "^11.0.0",
-          "semver": "^7.3.5"
-        },
-        "engines": {
-          "node": "^16.14.0 || >=18.0.0"
-        }
+      "bin": {
+        "discover": "dist/bin/discover.js"
       },
-      "packages/@apphosting/create": {
-        "version": "0.1.0",
-        "license": "Apache-2.0",
-        "dependencies": {
-          "commander": "^11.1.0",
-          "semver": "^7.5.4"
-        },
-        "bin": {
-          "create": "dist/bin/create.js"
-        },
-        "devDependencies": {
-          "@types/commander": "*",
-          "ts-node": "*"
-        }
+      "devDependencies": {
+        "@types/commander": "*",
+        "@types/npmcli__arborist": "*",
+        "@types/yarnpkg__lockfile": "*"
+      }
+    },
+    "packages/@apphosting/discover/node_modules/hosted-git-info": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.1.tgz",
+      "integrity": "sha512-+K84LB1DYwMHoHSgaOY/Jfhw3ucPmSET5v98Ke/HdNSw4a0UktWzyW1mjhjpuxxTqOOsfWT/7iVshHmVZ4IpOA==",
+      "dependencies": {
+        "lru-cache": "^10.0.1"
       },
-      "packages/@apphosting/discover": {
-        "version": "0.1.0",
-        "license": "Apache-2.0",
-        "dependencies": {
-          "@npmcli/arborist": "^7.2.1",
-          "@yarnpkg/lockfile": "^1.1.0",
-          "colorette": "^2.0.20",
-          "commander": "^11.1.0",
-          "fs-extra": "^11.1.1",
-          "npm-pick-manifest": "^9.0.0",
-          "toml": "^3.0.0",
-          "ts-node": "^10.9.1",
-          "yaml": "^2.3.4"
-        },
-        "bin": {
-          "discover": "dist/bin/discover.js"
-        },
-        "devDependencies": {
-          "@types/commander": "*",
-          "@types/npmcli__arborist": "*",
-          "@types/yarnpkg__lockfile": "*"
-        }
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "packages/@apphosting/discover/node_modules/lru-cache": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.1.0.tgz",
+      "integrity": "sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==",
+      "engines": {
+        "node": "14 || >=16.14"
+      }
+    },
+    "packages/@apphosting/discover/node_modules/npm-normalize-package-bin": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-3.0.1.tgz",
+      "integrity": "sha512-dMxCf+zZ+3zeQZXKxmyuCKlIDPGuv8EF940xbkC4kQVDTtqoh6rJFO+JTKSA6/Rwi0getWmtuy4Itup0AMcaDQ==",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "packages/@apphosting/discover/node_modules/npm-package-arg": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-11.0.1.tgz",
+      "integrity": "sha512-M7s1BD4NxdAvBKUPqqRW957Xwcl/4Zvo8Aj+ANrzvIPzGJZElrH7Z//rSaec2ORcND6FHHLnZeY8qgTpXDMFQQ==",
+      "dependencies": {
+        "hosted-git-info": "^7.0.0",
+        "proc-log": "^3.0.0",
+        "semver": "^7.3.5",
+        "validate-npm-package-name": "^5.0.0"
       },
-      "packages/@apphosting/discover/node_modules/hosted-git-info": {
-        "version": "7.0.1",
-        "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.1.tgz",
-        "integrity": "sha512-+K84LB1DYwMHoHSgaOY/Jfhw3ucPmSET5v98Ke/HdNSw4a0UktWzyW1mjhjpuxxTqOOsfWT/7iVshHmVZ4IpOA==",
-        "dependencies": {
-          "lru-cache": "^10.0.1"
-        },
-        "engines": {
-          "node": "^16.14.0 || >=18.0.0"
-        }
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "packages/@apphosting/discover/node_modules/npm-pick-manifest": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-9.0.0.tgz",
+      "integrity": "sha512-VfvRSs/b6n9ol4Qb+bDwNGUXutpy76x6MARw/XssevE0TnctIKcmklJZM5Z7nqs5z5aW+0S63pgCNbpkUNNXBg==",
+      "dependencies": {
+        "npm-install-checks": "^6.0.0",
+        "npm-normalize-package-bin": "^3.0.0",
+        "npm-package-arg": "^11.0.0",
+        "semver": "^7.3.5"
       },
-      "packages/@apphosting/discover/node_modules/lru-cache": {
-        "version": "10.1.0",
-        "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.1.0.tgz",
-        "integrity": "sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==",
-        "engines": {
-          "node": "14 || >=16.14"
-        }
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "packages/firebase-frameworks": {
+      "version": "0.11.2",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@hapi/accept": "^6.0.1",
+        "cookie": "^0.5.0",
+        "lru-cache": "^7.14.0",
+        "tslib": "^2.3.1"
       },
-      "packages/@apphosting/discover/node_modules/npm-normalize-package-bin": {
-        "version": "3.0.1",
-        "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-3.0.1.tgz",
-        "integrity": "sha512-dMxCf+zZ+3zeQZXKxmyuCKlIDPGuv8EF940xbkC4kQVDTtqoh6rJFO+JTKSA6/Rwi0getWmtuy4Itup0AMcaDQ==",
-        "engines": {
-          "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-        }
+      "devDependencies": {
+        "@sveltejs/kit": "^1.0.1",
+        "@types/cookie": "*",
+        "@types/lru-cache": "*",
+        "@types/node": "*",
+        "firebase": "^10.0.0",
+        "firebase-admin": "^11.0.1",
+        "firebase-functions": "^4.3.1",
+        "next": "~14.0.0",
+        "sharp": "*",
+        "ts-node": "*"
       },
-      "packages/@apphosting/discover/node_modules/npm-package-arg": {
-        "version": "11.0.1",
-        "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-11.0.1.tgz",
-        "integrity": "sha512-M7s1BD4NxdAvBKUPqqRW957Xwcl/4Zvo8Aj+ANrzvIPzGJZElrH7Z//rSaec2ORcND6FHHLnZeY8qgTpXDMFQQ==",
-        "dependencies": {
-          "hosted-git-info": "^7.0.0",
-          "proc-log": "^3.0.0",
-          "semver": "^7.3.5",
-          "validate-npm-package-name": "^5.0.0"
-        },
-        "engines": {
-          "node": "^16.14.0 || >=18.0.0"
-        }
+      "engines": {
+        "node": "^16.0.0 || ^18.0.0 || ^20.0.0"
       },
-      "packages/@apphosting/discover/node_modules/npm-pick-manifest": {
-        "version": "9.0.0",
-        "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-9.0.0.tgz",
-        "integrity": "sha512-VfvRSs/b6n9ol4Qb+bDwNGUXutpy76x6MARw/XssevE0TnctIKcmklJZM5Z7nqs5z5aW+0S63pgCNbpkUNNXBg==",
-        "dependencies": {
-          "npm-install-checks": "^6.0.0",
-          "npm-normalize-package-bin": "^3.0.0",
-          "npm-package-arg": "^11.0.0",
-          "semver": "^7.3.5"
-        },
-        "engines": {
-          "node": "^16.14.0 || >=18.0.0"
-        }
+      "peerDependencies": {
+        "firebase": "^9.9.0 || ^10.0.0",
+        "firebase-admin": "^11.0.1 || ^12.0.0",
+        "sharp": "^0.32.1"
       },
-      "packages/firebase-frameworks": {
-        "version": "0.11.2",
-        "license": "Apache-2.0",
-        "dependencies": {
-          "@hapi/accept": "^6.0.1",
-          "cookie": "^0.5.0",
-          "lru-cache": "^7.14.0",
-          "tslib": "^2.3.1"
+      "peerDependenciesMeta": {
+        "firebase": {
+          "optional": true
         },
-        "devDependencies": {
-          "@sveltejs/kit": "^1.0.1",
-          "@types/cookie": "*",
-          "@types/lru-cache": "*",
-          "@types/node": "*",
-          "firebase": "^10.0.0",
-          "firebase-admin": "^11.0.1",
-          "firebase-functions": "^4.3.1",
-          "next": "~14.0.0",
-          "sharp": "*",
-          "ts-node": "*"
-        },
-        "engines": {
-          "node": "^16.0.0 || ^18.0.0 || ^20.0.0"
-        },
-        "peerDependencies": {
-          "firebase": "^9.9.0 || ^10.0.0",
-          "firebase-admin": "^11.0.1 || ^12.0.0",
-          "sharp": "^0.32.1"
-        },
-        "peerDependenciesMeta": {
-          "firebase": {
-            "optional": true
-          },
-          "sharp": {
-            "optional": true
-          }
+        "sharp": {
+          "optional": true
         }
-      },
-      "packages/firebase-frameworks/node_modules/lru-cache": {
-        "version": "7.18.3",
-        "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-        "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
-        "engines": {
-          "node": ">=12"
-        }
+      }
+    },
+    "packages/firebase-frameworks/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "engines": {
+        "node": ">=12"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -22674,7 +22674,6 @@
       "version": "3.22.4",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
       "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -22690,13 +22689,15 @@
       }
     },
     "packages/@apphosting/adapter-angular": {
-      "version": "17.0.0",
+      "version": "17.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "firebase-functions": "^4.3.1",
         "fs-extra": "^11.1.1",
+        "strip-ansi": "^7.1.0",
         "tslib": "^2.3.1",
-        "yaml": "^2.3.4"
+        "yaml": "^2.3.4",
+        "zod": "^3.22.4"
       },
       "bin": {
         "apphosting-adapter-angular-build": "dist/bin/build.js",
@@ -22743,6 +22744,31 @@
       "peerDependencies": {
         "rxjs": "^6.5.3 || ^7.4.0",
         "zone.js": "~0.14.0"
+      }
+    },
+    "packages/@apphosting/adapter-angular/node_modules/ansi-regex": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "packages/@apphosting/adapter-angular/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "packages/@apphosting/adapter-nextjs": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22689,7 +22689,7 @@
       }
     },
     "packages/@apphosting/adapter-angular": {
-      "version": "17.2.0",
+      "version": "17.2.2",
       "license": "Apache-2.0",
       "dependencies": {
         "firebase-functions": "^4.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22941,442 +22941,444 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-    "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.12.0.tgz",
-      "integrity": "sha512-+ac02NL/2TCKRrJu2wffk1kZ+RyqxVUlbjSagNgPm94frxtr+XDL12E5Ll1enWskLrtrZ2r8L3wED1orIibV/w==",
-      "cpu": [
-        "arm"
-      ],
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.12.0.tgz",
-      "integrity": "sha512-OBqcX2BMe6nvjQ0Nyp7cC90cnumt8PXmO7Dp3gfAju/6YwG0Tj74z1vKrfRz7qAv23nBcYM8BCbhrsWqO7PzQQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.12.0.tgz",
-      "integrity": "sha512-X64tZd8dRE/QTrBIEs63kaOBG0b5GVEd3ccoLtyf6IdXtHdh8h+I56C2yC3PtC9Ucnv0CpNFJLqKFVgCYe0lOQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.12.0.tgz",
-      "integrity": "sha512-cc71KUZoVbUJmGP2cOuiZ9HSOP14AzBAThn3OU+9LcA1+IUqswJyR1cAJj3Mg55HbjZP6OLAIscbQsQLrpgTOg==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.12.0.tgz",
-      "integrity": "sha512-a6w/Y3hyyO6GlpKL2xJ4IOh/7d+APaqLYdMf86xnczU3nurFTaVN9s9jOXQg97BE4nYm/7Ga51rjec5nfRdrvA==",
-      "cpu": [
-        "arm"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.12.0.tgz",
-      "integrity": "sha512-0fZBq27b+D7Ar5CQMofVN8sggOVhEtzFUwOwPppQt0k+VR+7UHMZZY4y+64WJ06XOhBTKXtQB/Sv0NwQMXyNAA==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.12.0.tgz",
-      "integrity": "sha512-eTvzUS3hhhlgeAv6bfigekzWZjaEX9xP9HhxB0Dvrdbkk5w/b+1Sxct2ZuDxNJKzsRStSq1EaEkVSEe7A7ipgQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.12.0.tgz",
-      "integrity": "sha512-ix+qAB9qmrCRiaO71VFfY8rkiAZJL8zQRXveS27HS+pKdjwUfEhqo2+YF2oI+H/22Xsiski+qqwIBxVewLK7sw==",
-      "cpu": [
-        "riscv64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.12.0.tgz",
-      "integrity": "sha512-TenQhZVOtw/3qKOPa7d+QgkeM6xY0LtwzR8OplmyL5LrgTWIXpTQg2Q2ycBf8jm+SFW2Wt/DTn1gf7nFp3ssVA==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.12.0.tgz",
-      "integrity": "sha512-LfFdRhNnW0zdMvdCb5FNuWlls2WbbSridJvxOvYWgSBOYZtgBfW9UGNJG//rwMqTX1xQE9BAodvMH9tAusKDUw==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.12.0.tgz",
-      "integrity": "sha512-JPDxovheWNp6d7AHCgsUlkuCKvtu3RB55iNEkaQcf0ttsDU/JZF+iQnYcQJSk/7PtT4mjjVG8N1kpwnI9SLYaw==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.12.0.tgz",
-      "integrity": "sha512-fjtuvMWRGJn1oZacG8IPnzIV6GF2/XG+h71FKn76OYFqySXInJtseAqdprVTDTyqPxQOG9Exak5/E9Z3+EJ8ZA==",
-      "cpu": [
-        "ia32"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.12.0.tgz",
-      "integrity": "sha512-ZYmr5mS2wd4Dew/JjT0Fqi2NPB/ZhZ2VvPp7SmvPZb4Y1CG/LRcS6tcRo2cYU7zLK5A7cdbhWnnWmUjoI4qapg==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "packages/@apphosting/adapter-angular/node_modules/rollup": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.12.0.tgz",
-      "integrity": "sha512-wz66wn4t1OHIJw3+XU7mJJQV/2NAfw5OAk6G6Hoo3zcvz/XOfQ52Vgi+AN4Uxoxi0KBBwk2g8zPrTDA4btSB/Q==",
-      "dependencies": {
-        "@types/estree": "1.0.5"
       },
-      "bin": {
-        "rollup": "dist/bin/rollup"
+      "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-android-arm-eabi": {
+        "version": "4.12.0",
+        "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.12.0.tgz",
+        "integrity": "sha512-+ac02NL/2TCKRrJu2wffk1kZ+RyqxVUlbjSagNgPm94frxtr+XDL12E5Ll1enWskLrtrZ2r8L3wED1orIibV/w==",
+        "cpu": [
+          "arm"
+        ],
+        "optional": true,
+        "os": [
+          "android"
+        ]
       },
-      "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=8.0.0"
+      "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-android-arm64": {
+        "version": "4.12.0",
+        "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.12.0.tgz",
+        "integrity": "sha512-OBqcX2BMe6nvjQ0Nyp7cC90cnumt8PXmO7Dp3gfAju/6YwG0Tj74z1vKrfRz7qAv23nBcYM8BCbhrsWqO7PzQQ==",
+        "cpu": [
+          "arm64"
+        ],
+        "optional": true,
+        "os": [
+          "android"
+        ]
       },
-      "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.12.0",
-        "@rollup/rollup-android-arm64": "4.12.0",
-        "@rollup/rollup-darwin-arm64": "4.12.0",
-        "@rollup/rollup-darwin-x64": "4.12.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.12.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.12.0",
-        "@rollup/rollup-linux-arm64-musl": "4.12.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.12.0",
-        "@rollup/rollup-linux-x64-gnu": "4.12.0",
-        "@rollup/rollup-linux-x64-musl": "4.12.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.12.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.12.0",
-        "@rollup/rollup-win32-x64-msvc": "4.12.0",
-        "fsevents": "~2.3.2"
-      }
-    },
-    "packages/@apphosting/adapter-angular/src/simple-server": {
-      "dependencies": {
-        "@rollup/plugin-json": "^6.1.0",
-        "express": "^4.18.2",
-        "rollup": "^4.12.0"
+      "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-darwin-arm64": {
+        "version": "4.12.0",
+        "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.12.0.tgz",
+        "integrity": "sha512-X64tZd8dRE/QTrBIEs63kaOBG0b5GVEd3ccoLtyf6IdXtHdh8h+I56C2yC3PtC9Ucnv0CpNFJLqKFVgCYe0lOQ==",
+        "cpu": [
+          "arm64"
+        ],
+        "optional": true,
+        "os": [
+          "darwin"
+        ]
       },
-      "devDependencies": {
-        "@rollup/plugin-node-resolve": "^15.2.3",
-        "rollup-plugin-commonjs": "^10.1.0",
-        "rollup-plugin-node-resolve": "^5.2.0"
-      }
-    },
-    "packages/@apphosting/adapter-nextjs": {
-      "version": "14.0.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "fs-extra": "^11.1.1",
-        "yaml": "^2.3.4"
+      "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-darwin-x64": {
+        "version": "4.12.0",
+        "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.12.0.tgz",
+        "integrity": "sha512-cc71KUZoVbUJmGP2cOuiZ9HSOP14AzBAThn3OU+9LcA1+IUqswJyR1cAJj3Mg55HbjZP6OLAIscbQsQLrpgTOg==",
+        "cpu": [
+          "x64"
+        ],
+        "optional": true,
+        "os": [
+          "darwin"
+        ]
       },
-      "bin": {
-        "apphosting-adapter-nextjs-build": "dist/bin/build.js",
-        "apphosting-adapter-nextjs-create": "dist/bin/create.js"
+      "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+        "version": "4.12.0",
+        "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.12.0.tgz",
+        "integrity": "sha512-a6w/Y3hyyO6GlpKL2xJ4IOh/7d+APaqLYdMf86xnczU3nurFTaVN9s9jOXQg97BE4nYm/7Ga51rjec5nfRdrvA==",
+        "cpu": [
+          "arm"
+        ],
+        "optional": true,
+        "os": [
+          "linux"
+        ]
       },
-      "devDependencies": {
-        "@types/fs-extra": "*",
-        "@types/tmp": "*",
-        "next": "~14.0.0",
-        "semver": "*",
-        "tmp": "*",
-        "ts-node": "*"
+      "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-linux-arm64-gnu": {
+        "version": "4.12.0",
+        "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.12.0.tgz",
+        "integrity": "sha512-0fZBq27b+D7Ar5CQMofVN8sggOVhEtzFUwOwPppQt0k+VR+7UHMZZY4y+64WJ06XOhBTKXtQB/Sv0NwQMXyNAA==",
+        "cpu": [
+          "arm64"
+        ],
+        "optional": true,
+        "os": [
+          "linux"
+        ]
       },
-      "peerDependencies": {
-        "next": "~14.0.0"
+      "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-linux-arm64-musl": {
+        "version": "4.12.0",
+        "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.12.0.tgz",
+        "integrity": "sha512-eTvzUS3hhhlgeAv6bfigekzWZjaEX9xP9HhxB0Dvrdbkk5w/b+1Sxct2ZuDxNJKzsRStSq1EaEkVSEe7A7ipgQ==",
+        "cpu": [
+          "arm64"
+        ],
+        "optional": true,
+        "os": [
+          "linux"
+        ]
       },
-      "peerDependenciesMeta": {
-        "next": {
-          "optional": true
-        }
-      }
-    },
-    "packages/@apphosting/build": {
-      "version": "0.1.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@apphosting/discover": "*",
-        "colorette": "^2.0.20",
-        "commander": "^11.1.0",
-        "npm-pick-manifest": "^9.0.0",
-        "ts-node": "^10.9.1"
+      "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-linux-riscv64-gnu": {
+        "version": "4.12.0",
+        "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.12.0.tgz",
+        "integrity": "sha512-ix+qAB9qmrCRiaO71VFfY8rkiAZJL8zQRXveS27HS+pKdjwUfEhqo2+YF2oI+H/22Xsiski+qqwIBxVewLK7sw==",
+        "cpu": [
+          "riscv64"
+        ],
+        "optional": true,
+        "os": [
+          "linux"
+        ]
       },
-      "bin": {
-        "build": "dist/bin/build.js"
+      "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-linux-x64-gnu": {
+        "version": "4.12.0",
+        "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.12.0.tgz",
+        "integrity": "sha512-TenQhZVOtw/3qKOPa7d+QgkeM6xY0LtwzR8OplmyL5LrgTWIXpTQg2Q2ycBf8jm+SFW2Wt/DTn1gf7nFp3ssVA==",
+        "cpu": [
+          "x64"
+        ],
+        "optional": true,
+        "os": [
+          "linux"
+        ]
       },
-      "devDependencies": {
-        "@types/commander": "*"
-      }
-    },
-    "packages/@apphosting/build/node_modules/hosted-git-info": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.1.tgz",
-      "integrity": "sha512-+K84LB1DYwMHoHSgaOY/Jfhw3ucPmSET5v98Ke/HdNSw4a0UktWzyW1mjhjpuxxTqOOsfWT/7iVshHmVZ4IpOA==",
-      "dependencies": {
-        "lru-cache": "^10.0.1"
+      "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-linux-x64-musl": {
+        "version": "4.12.0",
+        "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.12.0.tgz",
+        "integrity": "sha512-LfFdRhNnW0zdMvdCb5FNuWlls2WbbSridJvxOvYWgSBOYZtgBfW9UGNJG//rwMqTX1xQE9BAodvMH9tAusKDUw==",
+        "cpu": [
+          "x64"
+        ],
+        "optional": true,
+        "os": [
+          "linux"
+        ]
       },
-      "engines": {
-        "node": "^16.14.0 || >=18.0.0"
-      }
-    },
-    "packages/@apphosting/build/node_modules/lru-cache": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.1.0.tgz",
-      "integrity": "sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==",
-      "engines": {
-        "node": "14 || >=16.14"
-      }
-    },
-    "packages/@apphosting/build/node_modules/npm-normalize-package-bin": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-3.0.1.tgz",
-      "integrity": "sha512-dMxCf+zZ+3zeQZXKxmyuCKlIDPGuv8EF940xbkC4kQVDTtqoh6rJFO+JTKSA6/Rwi0getWmtuy4Itup0AMcaDQ==",
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "packages/@apphosting/build/node_modules/npm-package-arg": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-11.0.1.tgz",
-      "integrity": "sha512-M7s1BD4NxdAvBKUPqqRW957Xwcl/4Zvo8Aj+ANrzvIPzGJZElrH7Z//rSaec2ORcND6FHHLnZeY8qgTpXDMFQQ==",
-      "dependencies": {
-        "hosted-git-info": "^7.0.0",
-        "proc-log": "^3.0.0",
-        "semver": "^7.3.5",
-        "validate-npm-package-name": "^5.0.0"
+      "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-win32-arm64-msvc": {
+        "version": "4.12.0",
+        "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.12.0.tgz",
+        "integrity": "sha512-JPDxovheWNp6d7AHCgsUlkuCKvtu3RB55iNEkaQcf0ttsDU/JZF+iQnYcQJSk/7PtT4mjjVG8N1kpwnI9SLYaw==",
+        "cpu": [
+          "arm64"
+        ],
+        "optional": true,
+        "os": [
+          "win32"
+        ]
       },
-      "engines": {
-        "node": "^16.14.0 || >=18.0.0"
-      }
-    },
-    "packages/@apphosting/build/node_modules/npm-pick-manifest": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-9.0.0.tgz",
-      "integrity": "sha512-VfvRSs/b6n9ol4Qb+bDwNGUXutpy76x6MARw/XssevE0TnctIKcmklJZM5Z7nqs5z5aW+0S63pgCNbpkUNNXBg==",
-      "dependencies": {
-        "npm-install-checks": "^6.0.0",
-        "npm-normalize-package-bin": "^3.0.0",
-        "npm-package-arg": "^11.0.0",
-        "semver": "^7.3.5"
+      "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-win32-ia32-msvc": {
+        "version": "4.12.0",
+        "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.12.0.tgz",
+        "integrity": "sha512-fjtuvMWRGJn1oZacG8IPnzIV6GF2/XG+h71FKn76OYFqySXInJtseAqdprVTDTyqPxQOG9Exak5/E9Z3+EJ8ZA==",
+        "cpu": [
+          "ia32"
+        ],
+        "optional": true,
+        "os": [
+          "win32"
+        ]
       },
-      "engines": {
-        "node": "^16.14.0 || >=18.0.0"
-      }
-    },
-    "packages/@apphosting/create": {
-      "version": "0.1.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "commander": "^11.1.0",
-        "semver": "^7.5.4"
+      "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-win32-x64-msvc": {
+        "version": "4.12.0",
+        "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.12.0.tgz",
+        "integrity": "sha512-ZYmr5mS2wd4Dew/JjT0Fqi2NPB/ZhZ2VvPp7SmvPZb4Y1CG/LRcS6tcRo2cYU7zLK5A7cdbhWnnWmUjoI4qapg==",
+        "cpu": [
+          "x64"
+        ],
+        "optional": true,
+        "os": [
+          "win32"
+        ]
       },
-      "bin": {
-        "create": "dist/bin/create.js"
-      },
-      "devDependencies": {
-        "@types/commander": "*",
-        "ts-node": "*"
-      }
-    },
-    "packages/@apphosting/discover": {
-      "version": "0.1.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@npmcli/arborist": "^7.2.1",
-        "@yarnpkg/lockfile": "^1.1.0",
-        "colorette": "^2.0.20",
-        "commander": "^11.1.0",
-        "fs-extra": "^11.1.1",
-        "npm-pick-manifest": "^9.0.0",
-        "toml": "^3.0.0",
-        "ts-node": "^10.9.1",
-        "yaml": "^2.3.4"
-      },
-      "bin": {
-        "discover": "dist/bin/discover.js"
-      },
-      "devDependencies": {
-        "@types/commander": "*",
-        "@types/npmcli__arborist": "*",
-        "@types/yarnpkg__lockfile": "*"
-      }
-    },
-    "packages/@apphosting/discover/node_modules/hosted-git-info": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.1.tgz",
-      "integrity": "sha512-+K84LB1DYwMHoHSgaOY/Jfhw3ucPmSET5v98Ke/HdNSw4a0UktWzyW1mjhjpuxxTqOOsfWT/7iVshHmVZ4IpOA==",
-      "dependencies": {
-        "lru-cache": "^10.0.1"
-      },
-      "engines": {
-        "node": "^16.14.0 || >=18.0.0"
-      }
-    },
-    "packages/@apphosting/discover/node_modules/lru-cache": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.1.0.tgz",
-      "integrity": "sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==",
-      "engines": {
-        "node": "14 || >=16.14"
-      }
-    },
-    "packages/@apphosting/discover/node_modules/npm-normalize-package-bin": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-3.0.1.tgz",
-      "integrity": "sha512-dMxCf+zZ+3zeQZXKxmyuCKlIDPGuv8EF940xbkC4kQVDTtqoh6rJFO+JTKSA6/Rwi0getWmtuy4Itup0AMcaDQ==",
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "packages/@apphosting/discover/node_modules/npm-package-arg": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-11.0.1.tgz",
-      "integrity": "sha512-M7s1BD4NxdAvBKUPqqRW957Xwcl/4Zvo8Aj+ANrzvIPzGJZElrH7Z//rSaec2ORcND6FHHLnZeY8qgTpXDMFQQ==",
-      "dependencies": {
-        "hosted-git-info": "^7.0.0",
-        "proc-log": "^3.0.0",
-        "semver": "^7.3.5",
-        "validate-npm-package-name": "^5.0.0"
-      },
-      "engines": {
-        "node": "^16.14.0 || >=18.0.0"
-      }
-    },
-    "packages/@apphosting/discover/node_modules/npm-pick-manifest": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-9.0.0.tgz",
-      "integrity": "sha512-VfvRSs/b6n9ol4Qb+bDwNGUXutpy76x6MARw/XssevE0TnctIKcmklJZM5Z7nqs5z5aW+0S63pgCNbpkUNNXBg==",
-      "dependencies": {
-        "npm-install-checks": "^6.0.0",
-        "npm-normalize-package-bin": "^3.0.0",
-        "npm-package-arg": "^11.0.0",
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": "^16.14.0 || >=18.0.0"
-      }
-    },
-    "packages/firebase-frameworks": {
-      "version": "0.11.2",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@hapi/accept": "^6.0.1",
-        "cookie": "^0.5.0",
-        "lru-cache": "^7.14.0",
-        "tslib": "^2.3.1"
-      },
-      "devDependencies": {
-        "@sveltejs/kit": "^1.0.1",
-        "@types/cookie": "*",
-        "@types/lru-cache": "*",
-        "@types/node": "*",
-        "firebase": "^10.0.0",
-        "firebase-admin": "^11.0.1",
-        "firebase-functions": "^4.3.1",
-        "next": "~14.0.0",
-        "sharp": "*",
-        "ts-node": "*"
-      },
-      "engines": {
-        "node": "^16.0.0 || ^18.0.0 || ^20.0.0"
-      },
-      "peerDependencies": {
-        "firebase": "^9.9.0 || ^10.0.0",
-        "firebase-admin": "^11.0.1 || ^12.0.0",
-        "sharp": "^0.32.1"
-      },
-      "peerDependenciesMeta": {
-        "firebase": {
-          "optional": true
+      "packages/@apphosting/adapter-angular/node_modules/rollup": {
+        "version": "4.12.0",
+        "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.12.0.tgz",
+        "integrity": "sha512-wz66wn4t1OHIJw3+XU7mJJQV/2NAfw5OAk6G6Hoo3zcvz/XOfQ52Vgi+AN4Uxoxi0KBBwk2g8zPrTDA4btSB/Q==",
+        "dependencies": {
+          "@types/estree": "1.0.5"
         },
-        "sharp": {
-          "optional": true
+        "bin": {
+          "rollup": "dist/bin/rollup"
+        },
+        "engines": {
+          "node": ">=18.0.0",
+          "npm": ">=8.0.0"
+        },
+        "optionalDependencies": {
+          "@rollup/rollup-android-arm-eabi": "4.12.0",
+          "@rollup/rollup-android-arm64": "4.12.0",
+          "@rollup/rollup-darwin-arm64": "4.12.0",
+          "@rollup/rollup-darwin-x64": "4.12.0",
+          "@rollup/rollup-linux-arm-gnueabihf": "4.12.0",
+          "@rollup/rollup-linux-arm64-gnu": "4.12.0",
+          "@rollup/rollup-linux-arm64-musl": "4.12.0",
+          "@rollup/rollup-linux-riscv64-gnu": "4.12.0",
+          "@rollup/rollup-linux-x64-gnu": "4.12.0",
+          "@rollup/rollup-linux-x64-musl": "4.12.0",
+          "@rollup/rollup-win32-arm64-msvc": "4.12.0",
+          "@rollup/rollup-win32-ia32-msvc": "4.12.0",
+          "@rollup/rollup-win32-x64-msvc": "4.12.0",
+          "fsevents": "~2.3.2"
         }
-      }
-    },
-    "packages/firebase-frameworks/node_modules/lru-cache": {
-      "version": "7.18.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
-      "engines": {
-        "node": ">=12"
+      },
+      "packages/@apphosting/adapter-angular/src/simple-server": {
+        "dependencies": {
+          "@rollup/plugin-json": "^6.1.0",
+          "express": "^4.18.2",
+          "rollup": "^4.12.0"
+        },
+        "devDependencies": {
+          "@rollup/plugin-node-resolve": "^15.2.3",
+          "rollup-plugin-commonjs": "^10.1.0",
+          "rollup-plugin-node-resolve": "^5.2.0"
+        }
+      },
+      "packages/@apphosting/adapter-nextjs": {
+        "version": "14.0.0",
+        "license": "Apache-2.0",
+        "dependencies": {
+          "fs-extra": "^11.1.1",
+          "yaml": "^2.3.4"
+        },
+        "bin": {
+          "apphosting-adapter-nextjs-build": "dist/bin/build.js",
+          "apphosting-adapter-nextjs-create": "dist/bin/create.js"
+        },
+        "devDependencies": {
+          "@types/fs-extra": "*",
+          "@types/tmp": "*",
+          "next": "~14.0.0",
+          "semver": "*",
+          "tmp": "*",
+          "ts-node": "*"
+        },
+        "peerDependencies": {
+          "next": "~14.0.0"
+        },
+        "peerDependenciesMeta": {
+          "next": {
+            "optional": true
+          }
+        }
+      },
+      "packages/@apphosting/build": {
+        "version": "0.1.0",
+        "license": "Apache-2.0",
+        "dependencies": {
+          "@apphosting/discover": "*",
+          "colorette": "^2.0.20",
+          "commander": "^11.1.0",
+          "npm-pick-manifest": "^9.0.0",
+          "ts-node": "^10.9.1"
+        },
+        "bin": {
+          "build": "dist/bin/build.js"
+        },
+        "devDependencies": {
+          "@types/commander": "*"
+        }
+      },
+      "packages/@apphosting/build/node_modules/hosted-git-info": {
+        "version": "7.0.1",
+        "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.1.tgz",
+        "integrity": "sha512-+K84LB1DYwMHoHSgaOY/Jfhw3ucPmSET5v98Ke/HdNSw4a0UktWzyW1mjhjpuxxTqOOsfWT/7iVshHmVZ4IpOA==",
+        "dependencies": {
+          "lru-cache": "^10.0.1"
+        },
+        "engines": {
+          "node": "^16.14.0 || >=18.0.0"
+        }
+      },
+      "packages/@apphosting/build/node_modules/lru-cache": {
+        "version": "10.1.0",
+        "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.1.0.tgz",
+        "integrity": "sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==",
+        "engines": {
+          "node": "14 || >=16.14"
+        }
+      },
+      "packages/@apphosting/build/node_modules/npm-normalize-package-bin": {
+        "version": "3.0.1",
+        "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-3.0.1.tgz",
+        "integrity": "sha512-dMxCf+zZ+3zeQZXKxmyuCKlIDPGuv8EF940xbkC4kQVDTtqoh6rJFO+JTKSA6/Rwi0getWmtuy4Itup0AMcaDQ==",
+        "engines": {
+          "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        }
+      },
+      "packages/@apphosting/build/node_modules/npm-package-arg": {
+        "version": "11.0.1",
+        "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-11.0.1.tgz",
+        "integrity": "sha512-M7s1BD4NxdAvBKUPqqRW957Xwcl/4Zvo8Aj+ANrzvIPzGJZElrH7Z//rSaec2ORcND6FHHLnZeY8qgTpXDMFQQ==",
+        "dependencies": {
+          "hosted-git-info": "^7.0.0",
+          "proc-log": "^3.0.0",
+          "semver": "^7.3.5",
+          "validate-npm-package-name": "^5.0.0"
+        },
+        "engines": {
+          "node": "^16.14.0 || >=18.0.0"
+        }
+      },
+      "packages/@apphosting/build/node_modules/npm-pick-manifest": {
+        "version": "9.0.0",
+        "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-9.0.0.tgz",
+        "integrity": "sha512-VfvRSs/b6n9ol4Qb+bDwNGUXutpy76x6MARw/XssevE0TnctIKcmklJZM5Z7nqs5z5aW+0S63pgCNbpkUNNXBg==",
+        "dependencies": {
+          "npm-install-checks": "^6.0.0",
+          "npm-normalize-package-bin": "^3.0.0",
+          "npm-package-arg": "^11.0.0",
+          "semver": "^7.3.5"
+        },
+        "engines": {
+          "node": "^16.14.0 || >=18.0.0"
+        }
+      },
+      "packages/@apphosting/create": {
+        "version": "0.1.0",
+        "license": "Apache-2.0",
+        "dependencies": {
+          "commander": "^11.1.0",
+          "semver": "^7.5.4"
+        },
+        "bin": {
+          "create": "dist/bin/create.js"
+        },
+        "devDependencies": {
+          "@types/commander": "*",
+          "ts-node": "*"
+        }
+      },
+      "packages/@apphosting/discover": {
+        "version": "0.1.0",
+        "license": "Apache-2.0",
+        "dependencies": {
+          "@npmcli/arborist": "^7.2.1",
+          "@yarnpkg/lockfile": "^1.1.0",
+          "colorette": "^2.0.20",
+          "commander": "^11.1.0",
+          "fs-extra": "^11.1.1",
+          "npm-pick-manifest": "^9.0.0",
+          "toml": "^3.0.0",
+          "ts-node": "^10.9.1",
+          "yaml": "^2.3.4"
+        },
+        "bin": {
+          "discover": "dist/bin/discover.js"
+        },
+        "devDependencies": {
+          "@types/commander": "*",
+          "@types/npmcli__arborist": "*",
+          "@types/yarnpkg__lockfile": "*"
+        }
+      },
+      "packages/@apphosting/discover/node_modules/hosted-git-info": {
+        "version": "7.0.1",
+        "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.1.tgz",
+        "integrity": "sha512-+K84LB1DYwMHoHSgaOY/Jfhw3ucPmSET5v98Ke/HdNSw4a0UktWzyW1mjhjpuxxTqOOsfWT/7iVshHmVZ4IpOA==",
+        "dependencies": {
+          "lru-cache": "^10.0.1"
+        },
+        "engines": {
+          "node": "^16.14.0 || >=18.0.0"
+        }
+      },
+      "packages/@apphosting/discover/node_modules/lru-cache": {
+        "version": "10.1.0",
+        "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.1.0.tgz",
+        "integrity": "sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==",
+        "engines": {
+          "node": "14 || >=16.14"
+        }
+      },
+      "packages/@apphosting/discover/node_modules/npm-normalize-package-bin": {
+        "version": "3.0.1",
+        "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-3.0.1.tgz",
+        "integrity": "sha512-dMxCf+zZ+3zeQZXKxmyuCKlIDPGuv8EF940xbkC4kQVDTtqoh6rJFO+JTKSA6/Rwi0getWmtuy4Itup0AMcaDQ==",
+        "engines": {
+          "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        }
+      },
+      "packages/@apphosting/discover/node_modules/npm-package-arg": {
+        "version": "11.0.1",
+        "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-11.0.1.tgz",
+        "integrity": "sha512-M7s1BD4NxdAvBKUPqqRW957Xwcl/4Zvo8Aj+ANrzvIPzGJZElrH7Z//rSaec2ORcND6FHHLnZeY8qgTpXDMFQQ==",
+        "dependencies": {
+          "hosted-git-info": "^7.0.0",
+          "proc-log": "^3.0.0",
+          "semver": "^7.3.5",
+          "validate-npm-package-name": "^5.0.0"
+        },
+        "engines": {
+          "node": "^16.14.0 || >=18.0.0"
+        }
+      },
+      "packages/@apphosting/discover/node_modules/npm-pick-manifest": {
+        "version": "9.0.0",
+        "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-9.0.0.tgz",
+        "integrity": "sha512-VfvRSs/b6n9ol4Qb+bDwNGUXutpy76x6MARw/XssevE0TnctIKcmklJZM5Z7nqs5z5aW+0S63pgCNbpkUNNXBg==",
+        "dependencies": {
+          "npm-install-checks": "^6.0.0",
+          "npm-normalize-package-bin": "^3.0.0",
+          "npm-package-arg": "^11.0.0",
+          "semver": "^7.3.5"
+        },
+        "engines": {
+          "node": "^16.14.0 || >=18.0.0"
+        }
+      },
+      "packages/firebase-frameworks": {
+        "version": "0.11.2",
+        "license": "Apache-2.0",
+        "dependencies": {
+          "@hapi/accept": "^6.0.1",
+          "cookie": "^0.5.0",
+          "lru-cache": "^7.14.0",
+          "tslib": "^2.3.1"
+        },
+        "devDependencies": {
+          "@sveltejs/kit": "^1.0.1",
+          "@types/cookie": "*",
+          "@types/lru-cache": "*",
+          "@types/node": "*",
+          "firebase": "^10.0.0",
+          "firebase-admin": "^11.0.1",
+          "firebase-functions": "^4.3.1",
+          "next": "~14.0.0",
+          "sharp": "*",
+          "ts-node": "*"
+        },
+        "engines": {
+          "node": "^16.0.0 || ^18.0.0 || ^20.0.0"
+        },
+        "peerDependencies": {
+          "firebase": "^9.9.0 || ^10.0.0",
+          "firebase-admin": "^11.0.1 || ^12.0.0",
+          "sharp": "^0.32.1"
+        },
+        "peerDependenciesMeta": {
+          "firebase": {
+            "optional": true
+          },
+          "sharp": {
+            "optional": true
+          }
+        }
+      },
+      "packages/firebase-frameworks/node_modules/lru-cache": {
+        "version": "7.18.3",
+        "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+        "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+        "engines": {
+          "node": ">=12"
+        }
       }
     }
   }

--- a/packages/@apphosting/adapter-angular/package.json
+++ b/packages/@apphosting/adapter-angular/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@apphosting/adapter-angular",
-    "version": "17.2.0",
+    "version": "17.2.2",
     "main": "dist/index.js",
     "description": "Experimental addon to the Firebase CLI to add web framework support",
     "repository": {

--- a/packages/@apphosting/adapter-angular/package.json
+++ b/packages/@apphosting/adapter-angular/package.json
@@ -39,10 +39,11 @@
     ],
     "license": "Apache-2.0",
     "dependencies": {
-        "fs-extra": "^11.1.1",
-        "yaml": "^2.3.4",
-        "tslib": "^2.3.1",
         "firebase-functions": "^4.3.1",
+        "fs-extra": "^11.1.1",
+        "strip-ansi": "^7.1.0",
+        "tslib": "^2.3.1",
+        "yaml": "^2.3.4",
         "zod": "^3.22.4"
     },
     "peerDependencies": {
@@ -50,8 +51,12 @@
         "@angular-devkit/core": "~17.0.0"
     },
     "peerDependenciesMeta": {
-        "@angular-devkit/architect": { "optional": true },
-        "@angular-devkit/core": { "optional": true }
+        "@angular-devkit/architect": {
+            "optional": true
+        },
+        "@angular-devkit/core": {
+            "optional": true
+        }
     },
     "devDependencies": {
         "@angular-devkit/architect": "~0.1700.0",
@@ -60,11 +65,11 @@
         "@types/fs-extra": "*",
         "@types/mocha": "*",
         "@types/tmp": "*",
+        "mocha": "*",
         "semver": "*",
         "tmp": "*",
-        "ts-node": "*",
-        "mocha": "*",
         "ts-mocha": "*",
+        "ts-node": "*",
         "typescript": "*"
     }
 }

--- a/packages/@apphosting/adapter-angular/src/bin/build.ts
+++ b/packages/@apphosting/adapter-angular/src/bin/build.ts
@@ -1,5 +1,11 @@
 #! /usr/bin/env node
-import { checkBuildConditions, build, generateOutputDirectory, DEFAULT_COMMAND } from "../utils.js";
+import {
+  build,
+  generateOutputDirectory,
+  DEFAULT_COMMAND,
+  checkStandaloneBuildConditions,
+  checkMonorepoBuildConditions,
+} from "../utils.js";
 
 const root = process.cwd();
 
@@ -7,8 +13,10 @@ const root = process.cwd();
 let projectRoot = root;
 if (process.env.MONOREPO_PROJECT && process.env.FIREBASE_APP_DIRECTORY) {
   projectRoot = projectRoot.concat("/", process.env.FIREBASE_APP_DIRECTORY);
+  const builder = process.env.MONOREPO_BUILDER || "";
+  checkMonorepoBuildConditions(builder);
 } else {
-  await checkBuildConditions(projectRoot);
+  await checkStandaloneBuildConditions(projectRoot);
 }
 
 // Determine which build runner to use

--- a/packages/@apphosting/adapter-angular/src/bin/build.ts
+++ b/packages/@apphosting/adapter-angular/src/bin/build.ts
@@ -1,9 +1,33 @@
 #! /usr/bin/env node
-import { checkBuildConditions, build, generateOutputDirectory } from "../utils.js";
+import { checkStandaloneBuildConditions, build, generateOutputDirectory } from "../utils.js";
+
+// Check if monorepo is being used
+const monorepoProject = process.env.MONOREPO_PROJECT;
+const monorepoCmd = process.env.MONOREPO_CMD;
 
 const cwd = process.cwd();
 
-await checkBuildConditions(cwd);
+let project = cwd;
+if (monorepoProject) {
+  project = project + "/" + monorepoProject;
+} else {
+  await checkStandaloneBuildConditions(project);
+}
 
-const outputBundleOptions = await build().catch(() => process.exit(1));
-await generateOutputDirectory(cwd, outputBundleOptions);
+let cmd = "npm";
+if (monorepoCmd) {
+  cmd = monorepoCmd;
+}
+
+console.log("CWD:", cwd);
+console.log("PROJECT:", project);
+console.log("COMMAND:", cmd);
+
+try {
+  const outputBundleOptions = await build(project, cmd);
+  console.log("OUTPUT BUNDLE OPTS", outputBundleOptions);
+  await generateOutputDirectory(cwd, outputBundleOptions);
+} catch (error) {
+  console.error(`Build failed with error: ${error}`);
+  process.exit(1);
+}

--- a/packages/@apphosting/adapter-angular/src/utils.ts
+++ b/packages/@apphosting/adapter-angular/src/utils.ts
@@ -12,13 +12,14 @@ import stripAnsi from "strip-ansi";
 export const { writeFile, move, readJson } = fsExtra;
 
 export const DEFAULT_COMMAND = "npm";
+export const REQUIRED_BUILDER = "@angular-devkit/build-angular:application";
 
 /**
  * Check if the following build conditions are satisfied for the workspace:
  * - The workspace does not contain multiple angular projects.
  * - The angular project must be using the application builder.
  */
-export async function checkBuildConditions(cwd: string): Promise<void> {
+export async function checkStandaloneBuildConditions(cwd: string): Promise<void> {
   // dynamically load Angular so this can be used in an NPX context
   const { NodeJsAsyncHost }: typeof import("@angular-devkit/core/node") = await import(
     `${cwd}/node_modules/@angular-devkit/core/node/index.js`
@@ -44,7 +45,16 @@ export async function checkBuildConditions(cwd: string): Promise<void> {
   if (!workspaceProject.targets.has(target)) throw new Error("Could not find build target.");
 
   const { builder } = workspaceProject.targets.get(target)!;
-  if (builder !== "@angular-devkit/build-angular:application") {
+  if (builder !== REQUIRED_BUILDER) {
+    throw new Error("Only the Angular application builder is supported.");
+  }
+}
+
+/**
+ * Check if the monorepo build system is using the Angular application builder.
+ */
+export function checkMonorepoBuildConditions(builder: string): void {
+  if (builder !== REQUIRED_BUILDER) {
     throw new Error("Only the Angular application builder is supported.");
   }
 }

--- a/packages/@apphosting/adapter-angular/src/utils.ts
+++ b/packages/@apphosting/adapter-angular/src/utils.ts
@@ -98,13 +98,10 @@ export const build = (
         reject(new Error(`Process exited with error code ${code}`));
       }
       try {
-        // console.log("BUILD OUTPUT:", buildOutput);
         const strippedManifest = extractManifestOutput(buildOutput);
         const parsedManifest = JSON.parse(strippedManifest) as string;
-        // console.log("PARSED MANIFEST", parsedManifest);
         // validate if the manifest is of the expected form
         manifest = buildManifestSchema.parse(parsedManifest);
-        // console.log("MANIFEST", manifest);
         if (manifest["errors"].length > 0) {
           // errors when extracting manifest
           manifest.errors.forEach((error) => {

--- a/packages/@apphosting/adapter-angular/src/utils.ts
+++ b/packages/@apphosting/adapter-angular/src/utils.ts
@@ -101,11 +101,11 @@ export const build = (
     });
 
     childProcess.on("exit", (code) => {
+      if (code !== 0) {
+        reject(new Error(`Process exited with error code ${code}. Output: ${buildOutput}`));
+      }
       if (!buildOutput) {
         reject(new Error("Unable to locate build manifest with output paths."));
-      }
-      if (code !== 0) {
-        reject(new Error(`Process exited with error code ${code}`));
       }
       try {
         const strippedManifest = extractManifestOutput(buildOutput);

--- a/packages/@apphosting/adapter-angular/src/utils.ts
+++ b/packages/@apphosting/adapter-angular/src/utils.ts
@@ -6,16 +6,17 @@ import { spawn } from "child_process";
 import { resolve, normalize, relative } from "path";
 import { stringify as yamlStringify } from "yaml";
 import { OutputPathOptions, OutputPaths, buildManifestSchema, ValidManifest } from "./interface.js";
+import stripAnsi from "strip-ansi";
 
 // fs-extra is CJS, readJson can't be imported using shorthand
 export const { writeFile, move, readJson } = fsExtra;
 
-/*
- Check if build conditions are satisfied for the workspace:
- The workspace cannot contain multiple angular projects.
- The angular project must be using application builder.
-*/
-export async function checkBuildConditions(cwd: string): Promise<void> {
+/**
+ * Check if the following build conditions are satisfied for the workspace:
+ * - The workspace does not contain multiple angular projects.
+ * - The angular project must be using the application builder.
+ */
+export async function checkStandaloneBuildConditions(cwd: string): Promise<void> {
   // dynamically load Angular so this can be used in an NPX context
   const { NodeJsAsyncHost }: typeof import("@angular-devkit/core/node") = await import(
     `${cwd}/node_modules/@angular-devkit/core/node/index.js`
@@ -68,56 +69,73 @@ export function populateOutputBundleOptions(outputPaths: OutputPaths): OutputPat
 }
 
 // Run build command
-export const build = (cwd = process.cwd()) =>
+export const build = (cwd = process.cwd(), cmd = "npm") =>
   new Promise<OutputPathOptions>((resolve, reject) => {
     // enable JSON build logs for application builder
     process.env.NG_BUILD_LOGS_JSON = "1";
-    const childProcess = spawn("npm", ["run", "build"], {
+    const childProcess = spawn(cmd, ["run", "build"], {
       cwd,
       shell: true,
       stdio: ["inherit", "pipe", "pipe"],
     });
-    let outputPathOptions = {} as OutputPathOptions;
+    let buildOutput = "";
     let manifest = {} as ValidManifest;
 
-    if (childProcess.stdout) {
-      childProcess.stdout.on("data", (data) => {
-        try {
-          if (data.toString().includes("outputPaths")) {
-            const parsedManifest = JSON.parse(data);
-            // validate if the manifest is of the expected form
-            manifest = buildManifestSchema.parse(parsedManifest);
-            if (manifest["errors"].length > 0) {
-              // errors when extracting manifest
-              manifest.errors.forEach((error) => {
-                logger.error(error);
-              });
-            }
-            if (manifest["warnings"].length > 0) {
-              // warnings when extracting manifest
-              manifest.warnings.forEach((warning) => {
-                logger.info(warning);
-              });
-            }
-            outputPathOptions = populateOutputBundleOptions(manifest["outputPaths"]);
-          }
-        } catch (error) {
-          throw new Error("Build manifest is not of expected structure: " + error);
-        }
-      });
-    } else {
-      throw new Error("Unable to locate build manifest with output paths.");
-    }
+    childProcess.stdout.on("data", (data: Buffer) => {
+      buildOutput += data.toString();
+    });
 
     childProcess.on("exit", (code) => {
-      if (code === 0) return resolve(outputPathOptions);
-      reject();
+      if (!buildOutput) {
+        reject(new Error("Unable to locate build manifest with output paths."));
+      }
+      if (code !== 0) {
+        reject(new Error(`Process exited with error code ${code}`));
+      }
+      try {
+        // console.log("BUILD OUTPUT:", buildOutput);
+        const strippedManifest = extractManifestOutput(buildOutput);
+        const parsedManifest = JSON.parse(strippedManifest) as string;
+        // console.log("PARSED MANIFEST", parsedManifest);
+        // validate if the manifest is of the expected form
+        manifest = buildManifestSchema.parse(parsedManifest);
+        // console.log("MANIFEST", manifest);
+        if (manifest["errors"].length > 0) {
+          // errors when extracting manifest
+          manifest.errors.forEach((error) => {
+            logger.error(error);
+          });
+        }
+        if (manifest["warnings"].length > 0) {
+          // warnings when extracting manifest
+          manifest.warnings.forEach((warning) => {
+            logger.info(warning);
+          });
+        }
+        resolve(populateOutputBundleOptions(manifest["outputPaths"]));
+      } catch (error) {
+        reject(new Error("Build manifest is not of expected structure: " + error));
+      }
     });
   });
 
-/* 
-Move the base output directory, which contains the server and browser bundle directory, and prerendered routes
-as well as generating bundle.yaml.
+/**
+ * Extracts build manifest from the build command's console output.
+ * N.B. Unfortunately, there is currently no consistent way to suppress extraneous default output from the task
+ * runners of monorepo tools such as Nx (such as using the --silent flag for npm scripts). As a result, we must
+ * temporarily resort to "cleaning" the output of executing the Angular application builder in a monorepo's tooling
+ * context, in order to extract the build manifest. This method is a potentially flaky stopgap until we can find a
+ * more reliable strategy.
+ */
+function extractManifestOutput(output: string): string {
+  const start = output.indexOf("{");
+  const end = output.lastIndexOf("}");
+  return stripAnsi(output.substring(start, end + 1));
+}
+
+/**
+ * Move the base output directory, which contains the server and browser bundle directory, and prerendered routes
+ * as well as generating bundle.yaml.
  */
 export async function generateOutputDirectory(
   cwd: string,


### PR DESCRIPTION
Currently, the Angular adapter is unable to specify a custom build command to run the Angular application builder. It also makes certain assumptions that no longer hold true in monorepo contexts. We adjust those conditions to enable builds of Angular projects using monorepo tooling.