### PR TITLE
Fix nextjs yarn pnp integration

### DIFF
--- a/packages/@apphosting/adapter-nextjs/src/bin/build.ts
+++ b/packages/@apphosting/adapter-nextjs/src/bin/build.ts
@@ -10,7 +10,7 @@ import { join } from "path";
 
 const cwd = process.cwd();
 
-build(cwd);
+await build(cwd);
 
 const outputBundleOptions = populateOutputBundleOptions(cwd);
 const { distDir } = await loadConfig(cwd);

--- a/packages/@apphosting/adapter-nextjs/src/utils.ts
+++ b/packages/@apphosting/adapter-nextjs/src/utils.ts
@@ -49,7 +49,7 @@ export async function build(cwd: string): Promise<void> {
   process.env.NEXT_PRIVATE_STANDALONE = "true";
   // Opt-out sending telemetry to Vercel
   process.env.NEXT_TELEMETRY_DISABLED = "1";
-  if (!(await exists(join(cwd, "node_modules")))) {
+  if (await exists(join(cwd, "yarn.lock"))) {
     spawnSync("yarn", ["build"], { cwd, shell: true, stdio: "inherit" });
   } else {
     spawnSync("npm", ["run", "build"], { cwd, shell: true, stdio: "inherit" });


### PR DESCRIPTION
Currently the nextjs adapter doesn't work if the app is built using yarn plug n play, this fixes that.