### PR TITLE
Use starters for App Hosting init

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        node: [16, 18, 20]
+        node: [18, 20]
       fail-fast: false
     name: Test Node ${{ matrix.node }}
     steps:

--- a/package-lock.json
+++ b/package-lock.json
@@ -9124,6 +9124,15 @@
       "integrity": "sha512-FafZwr1SnJEHlyPJeT5IRvsEjhvm3+dCNdy1OsAJZVrIKT0jNi3sFLbKRqVrHnnXEVI1rNljFGVEcuNG4PMuJw==",
       "dev": true
     },
+    "node_modules/@types/npmcli__promise-spawn": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/npmcli__promise-spawn/-/npmcli__promise-spawn-6.0.3.tgz",
+      "integrity": "sha512-4EQlesp5HtYHPXMXd4uuI+Q9hELEU0eVg/HBRLkqGC5U2ohwXZduCottmzPpb4tWCB+w4kQ3XNPlHIdXvCTyFw==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/npmlog": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@types/npmlog/-/npmlog-7.0.0.tgz",
@@ -13555,6 +13564,17 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-east-asian-width": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.2.0.tgz",
+      "integrity": "sha512-2nk+7SIVb14QrgXFHcm84tD4bKQz0RxPuMT8Ag5KPOq7J5fEmAg0UbXdTOSHqNuHSU28k55qnceesxXRZGzKWA==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.2.tgz",
@@ -16434,7 +16454,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -17896,7 +17915,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-      "dev": true,
       "dependencies": {
         "mimic-fn": "^2.1.0"
       },
@@ -20547,8 +20565,7 @@
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
     },
     "node_modules/sigstore": {
       "version": "1.9.0",
@@ -21085,6 +21102,17 @@
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/stdin-discarder": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
+      "integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/stream-events": {
@@ -23685,8 +23713,10 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^5.0.2",
+        "@npmcli/promise-spawn": "^7.0.2",
         "commander": "^11.1.0",
         "giget": "^1.2.3",
+        "ora": "^8.0.1",
         "semver": "^7.5.4"
       },
       "bin": {
@@ -23694,7 +23724,208 @@
       },
       "devDependencies": {
         "@types/commander": "*",
+        "@types/npmcli__promise-spawn": "^6.0.3",
         "ts-node": "*"
+      }
+    },
+    "packages/@apphosting/create/node_modules/@npmcli/promise-spawn": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-7.0.2.tgz",
+      "integrity": "sha512-xhfYPXoV5Dy4UkY0D+v2KkwvnDfiA/8Mt3sWCGI/hM03NsYIH8ZaG6QzS9x7pje5vHZBZJ2v6VRFVTWACnqcmQ==",
+      "dependencies": {
+        "which": "^4.0.0"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "packages/@apphosting/create/node_modules/ansi-regex": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "packages/@apphosting/create/node_modules/chalk": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "packages/@apphosting/create/node_modules/cli-cursor": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
+      "integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
+      "dependencies": {
+        "restore-cursor": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/@apphosting/create/node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/@apphosting/create/node_modules/emoji-regex": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.3.0.tgz",
+      "integrity": "sha512-QpLs9D9v9kArv4lfDEgg1X/gN5XLnf/A6l9cs8SPZLRZR3ZkY9+kwIQTxm+fsSej5UMYGE8fdoaZVIBlqG0XTw=="
+    },
+    "packages/@apphosting/create/node_modules/is-interactive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
+      "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/@apphosting/create/node_modules/is-unicode-supported": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.0.0.tgz",
+      "integrity": "sha512-FRdAyx5lusK1iHG0TWpVtk9+1i+GjrzRffhDg4ovQ7mcidMQ6mj+MhKPmvh7Xwyv5gIS06ns49CA7Sqg7lC22Q==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/@apphosting/create/node_modules/isexe": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
+      "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "packages/@apphosting/create/node_modules/log-symbols": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
+      "integrity": "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "is-unicode-supported": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/@apphosting/create/node_modules/log-symbols/node_modules/is-unicode-supported": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
+      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/@apphosting/create/node_modules/ora": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-8.0.1.tgz",
+      "integrity": "sha512-ANIvzobt1rls2BDny5fWZ3ZVKyD6nscLvfFRpQgfWsythlcsVUC9kL0zq6j2Z5z9wwp1kd7wpsD/T9qNPVLCaQ==",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "cli-cursor": "^4.0.0",
+        "cli-spinners": "^2.9.2",
+        "is-interactive": "^2.0.0",
+        "is-unicode-supported": "^2.0.0",
+        "log-symbols": "^6.0.0",
+        "stdin-discarder": "^0.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/@apphosting/create/node_modules/restore-cursor": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
+      "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/@apphosting/create/node_modules/string-width": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.1.0.tgz",
+      "integrity": "sha512-SEIJCWiX7Kg4c129n48aDRwLbFb2LJmXXFrWBG4NGaRtMQ3myKPKbwrD1BKqQn74oCoNMBVrfDEr5M9YxCsrkw==",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/@apphosting/create/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "packages/@apphosting/create/node_modules/which": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
+      "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
+      "dependencies": {
+        "isexe": "^3.1.1"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^16.13.0 || >=18.0.0"
       }
     },
     "packages/@apphosting/discover": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24008,8 +24008,62 @@
       }
     },
     "packages/create-next-on-firebase": {
-      "version": "0.1.0",
-      "license": "Apache-2.0"
+      "version": "0.1.2",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@npmcli/promise-spawn": "^7.0.2",
+        "commander": "^12.0.0",
+        "tslib": "^2.6.2"
+      },
+      "bin": {
+        "create": "dist/bin/create.js"
+      },
+      "devDependencies": {
+        "@types/commander": "*",
+        "@types/npmcli__promise-spawn": "^6.0.3",
+        "typescript": "*"
+      }
+    },
+    "packages/create-next-on-firebase/node_modules/@npmcli/promise-spawn": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-7.0.2.tgz",
+      "integrity": "sha512-xhfYPXoV5Dy4UkY0D+v2KkwvnDfiA/8Mt3sWCGI/hM03NsYIH8ZaG6QzS9x7pje5vHZBZJ2v6VRFVTWACnqcmQ==",
+      "dependencies": {
+        "which": "^4.0.0"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "packages/create-next-on-firebase/node_modules/commander": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.0.0.tgz",
+      "integrity": "sha512-MwVNWlYjDTtOjX5PiD7o5pK0UrFU/OYgcJfjjK4RaHZETNtjJqrZa9Y9ds88+A+f+d5lv+561eZ+yCKoS3gbAA==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/create-next-on-firebase/node_modules/isexe": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
+      "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "packages/create-next-on-firebase/node_modules/which": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
+      "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
+      "dependencies": {
+        "isexe": "^3.1.1"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^16.13.0 || >=18.0.0"
+      }
     },
     "packages/firebase-frameworks": {
       "version": "0.11.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24010,7 +24010,6 @@
       "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@inquirer/prompts": "^5.0.2",
         "@npmcli/promise-spawn": "^7.0.2",
         "commander": "^12.0.0",
         "tslib": "^2.6.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -4970,6 +4970,207 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@inquirer/checkbox": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-2.3.2.tgz",
+      "integrity": "sha512-lUXKA/5PhPBXz6SVDE+EbBmV3Wi3X77SPRet6Mc1pn6fSXAIivvu1OWpHDpVUxc+RiFflbrDjXUgLfCQeofrWg==",
+      "dependencies": {
+        "@inquirer/core": "^8.1.0",
+        "@inquirer/figures": "^1.0.1",
+        "@inquirer/type": "^1.3.1",
+        "ansi-escapes": "^4.3.2",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-3.1.6.tgz",
+      "integrity": "sha512-Mj4TU29g6Uy+37UtpA8UpEOI2icBfpCwSW1QDtfx60wRhUy90s/kHPif2OXSSvuwDQT1lhAYRWUfkNf9Tecxvg==",
+      "dependencies": {
+        "@inquirer/core": "^8.1.0",
+        "@inquirer/type": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-8.1.0.tgz",
+      "integrity": "sha512-kfx0SU9nWgGe1f03ao/uXc85SFH1v2w3vQVH7QDGjKxdtJz+7vPitFtG++BTyJMYyYgH8MpXigutcXJeiQwVRw==",
+      "dependencies": {
+        "@inquirer/figures": "^1.0.1",
+        "@inquirer/type": "^1.3.1",
+        "@types/mute-stream": "^0.0.4",
+        "@types/node": "^20.12.7",
+        "@types/wrap-ansi": "^3.0.0",
+        "ansi-escapes": "^4.3.2",
+        "chalk": "^4.1.2",
+        "cli-spinners": "^2.9.2",
+        "cli-width": "^4.1.0",
+        "mute-stream": "^1.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^6.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/mute-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
+      "integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@inquirer/editor": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-2.1.6.tgz",
+      "integrity": "sha512-CWmp6XhfQye6xwH6/XV1HGvY95rUfzw7EXyNDHzj5s5Qr1t/X3t6c7uRkfK7OD91y+sbSy7aL6MJv2bbNrMoew==",
+      "dependencies": {
+        "@inquirer/core": "^8.1.0",
+        "@inquirer/type": "^1.3.1",
+        "external-editor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/expand": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-2.1.6.tgz",
+      "integrity": "sha512-mFW/vU6mSut0UjmvxPdLC81Sz+5b4t7sMZeF7RlHki1PJkZVZIQoT91MCvoJJN2S7lDqSAV/TxeYqF41RNkY2g==",
+      "dependencies": {
+        "@inquirer/core": "^8.1.0",
+        "@inquirer/type": "^1.3.1",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.1.tgz",
+      "integrity": "sha512-mtup3wVKia3ZwULPHcbs4Mor8Voi+iIXEWD7wCNbIO6lYR62oPCTQyrddi5OMYVXHzeCSoneZwJuS8sBvlEwDw==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/input": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-2.1.6.tgz",
+      "integrity": "sha512-M8bUFOlcn/kQcVYskl4kkB6dYrHtymJJ1S4nSg/khXT3W3l71u2qhSzfo6PdBG3jUe6ILJZ0gUh4Kef2uJ5pxw==",
+      "dependencies": {
+        "@inquirer/core": "^8.1.0",
+        "@inquirer/type": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/password": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-2.1.6.tgz",
+      "integrity": "sha512-fkiTIijBRxotoMw0/ljA2BaSsz6PlGoiav9QyAjBXCZoyFsYoItstDKvJXbWwS9NrN42fXYvXn1ljBpldnJaeA==",
+      "dependencies": {
+        "@inquirer/core": "^8.1.0",
+        "@inquirer/type": "^1.3.1",
+        "ansi-escapes": "^4.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/prompts": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-5.0.2.tgz",
+      "integrity": "sha512-3OC7tyqa5E1I5Isnua9xfV8TO7y/n5jnNhGLAG8BLBtCu4jCftDewSdfjFJR0ld77trqjPP2udLxv0RbggJn9w==",
+      "dependencies": {
+        "@inquirer/checkbox": "^2.3.2",
+        "@inquirer/confirm": "^3.1.6",
+        "@inquirer/editor": "^2.1.6",
+        "@inquirer/expand": "^2.1.6",
+        "@inquirer/input": "^2.1.6",
+        "@inquirer/password": "^2.1.6",
+        "@inquirer/rawlist": "^2.1.6",
+        "@inquirer/select": "^2.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/rawlist": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-2.1.6.tgz",
+      "integrity": "sha512-xnGBfjatdUqyBMqHi1kHHBh4ggQGZz42vYH0kFdQDnOtx4Ouo7baqVZhBRuQfZTL8tAXuOYI9X6r6BXBl8cnqw==",
+      "dependencies": {
+        "@inquirer/core": "^8.1.0",
+        "@inquirer/type": "^1.3.1",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/select": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-2.3.2.tgz",
+      "integrity": "sha512-VzLHVpaobBpI3o/CWSG2sCDqrjHZEYAfT1bowbR8Q72fEi0WfBO3Fnh595QqBit9kQhI1uJbVHaaovg1I7eE7Q==",
+      "dependencies": {
+        "@inquirer/core": "^8.1.0",
+        "@inquirer/figures": "^1.0.1",
+        "@inquirer/type": "^1.3.1",
+        "ansi-escapes": "^4.3.2",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-1.3.1.tgz",
+      "integrity": "sha512-Pe3PFccjPVJV1vtlfVvm9OnlbxqdnP5QcscFEFEnK5quChf1ufZtM0r8mR5ToWHMxZOh0s8o/qp9ANGRTo/DAw==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -8845,10 +9046,18 @@
       "integrity": "sha512-dJvrYWxP/UcXm36Qn36fxhUKu8A/xMRXVT2cliFF1Z7UA9liG5Psj3ezNSZw+5puH2czDXRLcXQxf8JbJt0ejg==",
       "dev": true
     },
+    "node_modules/@types/mute-stream": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mute-stream/-/mute-stream-0.0.4.tgz",
+      "integrity": "sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/node": {
-      "version": "20.10.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.4.tgz",
-      "integrity": "sha512-D08YG6rr8X90YB56tSIuBaddy/UXAA9RKJoFvrsnogAum/0pmjkgi4+2nx96A330FmioegBWmEYQ+syqCFaveg==",
+      "version": "20.12.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.11.tgz",
+      "integrity": "sha512-vDg9PZ/zi+Nqp6boSOT7plNuthRugEKixDv5sFTIpkE89MmNtEArAShI4mxuX2+UrLEe9pxC1vm2cjm9YlWbJw==",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -9025,6 +9234,11 @@
       "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.6.tgz",
       "integrity": "sha512-chhaNf2oKHlRkDGt+tiKE2Z5aJ6qalm7Z9rlLdBwmOiAAf09YQvvoLXjWK4HWPF1xU/fqvMgfNfpVoBscA/tKA==",
       "dev": true
+    },
+    "node_modules/@types/wrap-ansi": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/wrap-ansi/-/wrap-ansi-3.0.0.tgz",
+      "integrity": "sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g=="
     },
     "node_modules/@types/ws": {
       "version": "8.5.10",
@@ -9671,7 +9885,6 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
       "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
-      "dev": true,
       "dependencies": {
         "type-fest": "^0.21.3"
       },
@@ -9686,7 +9899,6 @@
       "version": "0.21.3",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
       "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -10499,7 +10711,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "devOptional": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -10514,8 +10725,7 @@
     "node_modules/chardet": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
-      "dev": true
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
     },
     "node_modules/chokidar": {
       "version": "3.5.3",
@@ -10586,6 +10796,14 @@
       ],
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/citty": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/citty/-/citty-0.1.6.tgz",
+      "integrity": "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==",
+      "dependencies": {
+        "consola": "^3.2.3"
       }
     },
     "node_modules/clean-stack": {
@@ -10926,6 +11144,14 @@
       "dev": true,
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/consola": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.2.3.tgz",
+      "integrity": "sha512-I5qxpzLv+sJhTVEoLYNcTW+bThDCPsit0vLNKShZx6rLtpilNpmmeTPaeqJb9ZE9dV3DGaeby6Vuhrw38WjeyQ==",
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
       }
     },
     "node_modules/console-control-strings": {
@@ -11617,6 +11843,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/defu": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
+      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg=="
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
@@ -12578,7 +12809,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
       "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
-      "dev": true,
       "dependencies": {
         "chardet": "^0.7.0",
         "iconv-lite": "^0.4.24",
@@ -12592,7 +12822,6 @@
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-      "dev": true,
       "dependencies": {
         "os-tmpdir": "~1.0.2"
       },
@@ -13391,6 +13620,48 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/giget": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/giget/-/giget-1.2.3.tgz",
+      "integrity": "sha512-8EHPljDvs7qKykr6uw8b+lqLiUc/vUg+KVTI0uND4s63TdsZM2Xus3mflvF0DDG9SiM4RlCkFGL+7aAjRmV7KA==",
+      "dependencies": {
+        "citty": "^0.1.6",
+        "consola": "^3.2.3",
+        "defu": "^6.1.4",
+        "node-fetch-native": "^1.6.3",
+        "nypm": "^0.3.8",
+        "ohash": "^1.1.3",
+        "pathe": "^1.1.2",
+        "tar": "^6.2.0"
+      },
+      "bin": {
+        "giget": "dist/cli.mjs"
+      }
+    },
+    "node_modules/giget/node_modules/minipass": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/giget/node_modules/tar": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^5.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/git-raw-commits": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-3.0.0.tgz",
@@ -13737,7 +14008,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "devOptional": true,
       "engines": {
         "node": ">=8"
       }
@@ -16097,8 +16367,7 @@
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-      "dev": true
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -16668,6 +16937,11 @@
           "optional": true
         }
       }
+    },
+    "node_modules/node-fetch-native": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.4.tgz",
+      "integrity": "sha512-IhOigYzAKHd244OC0JIMIUrjzctirCmPkaIfhDeGcEETWof5zKYUW7e7MYvChGWh/4CJeXEgsRyGzuF334rOOQ=="
     },
     "node_modules/node-forge": {
       "version": "1.3.1",
@@ -17411,6 +17685,148 @@
         "node": ">=12"
       }
     },
+    "node_modules/nypm": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.3.8.tgz",
+      "integrity": "sha512-IGWlC6So2xv6V4cIDmoV0SwwWx7zLG086gyqkyumteH2fIgCAM4nDVFB2iDRszDvmdSVW9xb1N+2KjQ6C7d4og==",
+      "dependencies": {
+        "citty": "^0.1.6",
+        "consola": "^3.2.3",
+        "execa": "^8.0.1",
+        "pathe": "^1.1.2",
+        "ufo": "^1.4.0"
+      },
+      "bin": {
+        "nypm": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": "^14.16.0 || >=16.10.0"
+      }
+    },
+    "node_modules/nypm/node_modules/execa": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^8.0.1",
+        "human-signals": "^5.0.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/nypm/node_modules/get-stream": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/nypm/node_modules/human-signals": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
+    "node_modules/nypm/node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/nypm/node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/nypm/node_modules/npm-run-path": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/nypm/node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/nypm/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/nypm/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/nypm/node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -17441,6 +17857,11 @@
       "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
       "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
       "dev": true
+    },
+    "node_modules/ohash": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/ohash/-/ohash-1.1.3.tgz",
+      "integrity": "sha512-zuHHiGTYTA1sYJ/wZN+t5HKZaH23i4yI1HMwbuXm24Nid7Dv0KcuRlKoNKS9UNfAVSBlnGLcuQrnOKWOZoEGaw=="
     },
     "node_modules/on-finished": {
       "version": "2.4.1",
@@ -17547,7 +17968,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -18191,6 +18611,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ=="
     },
     "node_modules/periscopic": {
       "version": "3.1.0",
@@ -20842,7 +21267,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "devOptional": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -21774,6 +22198,11 @@
       "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
       "optional": true
     },
+    "node_modules/ufo": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.5.3.tgz",
+      "integrity": "sha512-Y7HYmWaFwPUmkoQCUIAYpKqkOf+SbVj/2fJJZ4RJMCfZp0rTGwRbzQD+HghfnhKOjL9E01okqz+ncJskGYfBNw=="
+    },
     "node_modules/uglify-js": {
       "version": "3.17.4",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
@@ -22533,7 +22962,6 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
       "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -23256,7 +23684,9 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@inquirer/prompts": "^5.0.2",
         "commander": "^11.1.0",
+        "giget": "^1.2.3",
         "semver": "^7.5.4"
       },
       "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -23709,7 +23709,7 @@
       }
     },
     "packages/@apphosting/create": {
-      "version": "0.2.1",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^5.0.2",
@@ -23725,7 +23725,6 @@
       "devDependencies": {
         "@types/commander": "*",
         "@types/npmcli__promise-spawn": "^6.0.3",
-        "ts-node": "*",
         "typescript": "*"
       }
     },
@@ -24008,9 +24007,10 @@
       }
     },
     "packages/create-next-on-firebase": {
-      "version": "0.1.2",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@inquirer/prompts": "^5.0.2",
         "@npmcli/promise-spawn": "^7.0.2",
         "commander": "^12.0.0",
         "tslib": "^2.6.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -23709,7 +23709,7 @@
       }
     },
     "packages/@apphosting/create": {
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^5.0.2",
@@ -23717,15 +23717,16 @@
         "commander": "^11.1.0",
         "giget": "^1.2.3",
         "ora": "^8.0.1",
-        "semver": "^7.5.4"
+        "tslib": "^2.3.1"
       },
       "bin": {
-        "apphosting-create": "dist/bin/create.js"
+        "create": "dist/bin/create.js"
       },
       "devDependencies": {
         "@types/commander": "*",
         "@types/npmcli__promise-spawn": "^6.0.3",
-        "ts-node": "*"
+        "ts-node": "*",
+        "typescript": "*"
       }
     },
     "packages/@apphosting/create/node_modules/@npmcli/promise-spawn": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -23709,7 +23709,7 @@
       }
     },
     "packages/@apphosting/create": {
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^5.0.2",
@@ -23720,7 +23720,7 @@
         "semver": "^7.5.4"
       },
       "bin": {
-        "create": "dist/bin/create.js"
+        "apphosting-create": "dist/bin/create.js"
       },
       "devDependencies": {
         "@types/commander": "*",

--- a/packages/@apphosting/create/package.json
+++ b/packages/@apphosting/create/package.json
@@ -33,7 +33,9 @@
     ],
     "license": "Apache-2.0",
     "dependencies": {
+        "@inquirer/prompts": "^5.0.2",
         "commander": "^11.1.0",
+        "giget": "^1.2.3",
         "semver": "^7.5.4"
     },
     "devDependencies": {

--- a/packages/@apphosting/create/package.json
+++ b/packages/@apphosting/create/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@apphosting/create",
-    "version": "0.2.0",
+    "version": "0.1.0",
     "main": "dist/index.js",
     "description": "Experimental addon to the Firebase CLI to add web framework support",
     "repository": {

--- a/packages/@apphosting/create/package.json
+++ b/packages/@apphosting/create/package.json
@@ -37,8 +37,7 @@
         "@npmcli/promise-spawn": "^7.0.2",
         "commander": "^11.1.0",
         "giget": "^1.2.3",
-        "ora": "^8.0.1",
-        "semver": "^7.5.4"
+        "ora": "^8.0.1"
     },
     "devDependencies": {
         "@types/commander": "*",

--- a/packages/@apphosting/create/package.json
+++ b/packages/@apphosting/create/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@apphosting/create",
-    "version": "0.1.0",
+    "version": "0.2.0",
     "main": "dist/index.js",
     "description": "Experimental addon to the Firebase CLI to add web framework support",
     "repository": {
@@ -8,7 +8,7 @@
         "url": "git+https://github.com/FirebaseExtended/firebase-framework-tools.git"
     },
     "bin": {
-        "@apphosting/create": "dist/bin/create.js"
+        "apphosting-create": "dist/bin/create.js"
     },
     "author": {
         "name": "Firebase",

--- a/packages/@apphosting/create/package.json
+++ b/packages/@apphosting/create/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@apphosting/create",
-    "version": "0.2.1",
+    "version": "0.3.0",
     "main": "dist/index.js",
     "description": "Experimental addon to the Firebase CLI to add web framework support",
     "repository": {

--- a/packages/@apphosting/create/package.json
+++ b/packages/@apphosting/create/package.json
@@ -37,11 +37,13 @@
         "@npmcli/promise-spawn": "^7.0.2",
         "commander": "^11.1.0",
         "giget": "^1.2.3",
-        "ora": "^8.0.1"
+        "ora": "^8.0.1",
+        "tslib": "^2.3.1"
     },
     "devDependencies": {
         "@types/commander": "*",
         "@types/npmcli__promise-spawn": "^6.0.3",
-        "ts-node": "*"
+        "ts-node": "*",
+        "typescript": "*"
     }
 }

--- a/packages/@apphosting/create/package.json
+++ b/packages/@apphosting/create/package.json
@@ -43,7 +43,6 @@
     "devDependencies": {
         "@types/commander": "*",
         "@types/npmcli__promise-spawn": "^6.0.3",
-        "ts-node": "*",
         "typescript": "*"
     }
 }

--- a/packages/@apphosting/create/package.json
+++ b/packages/@apphosting/create/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@apphosting/create",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "main": "dist/index.js",
     "description": "Experimental addon to the Firebase CLI to add web framework support",
     "repository": {
@@ -8,7 +8,7 @@
         "url": "git+https://github.com/FirebaseExtended/firebase-framework-tools.git"
     },
     "bin": {
-        "apphosting-create": "dist/bin/create.js"
+        "create": "dist/bin/create.js"
     },
     "author": {
         "name": "Firebase",

--- a/packages/@apphosting/create/package.json
+++ b/packages/@apphosting/create/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@apphosting/create",
-    "version": "0.1.0",
+    "version": "0.2.0",
     "main": "dist/index.js",
     "description": "Experimental addon to the Firebase CLI to add web framework support",
     "repository": {
@@ -34,12 +34,15 @@
     "license": "Apache-2.0",
     "dependencies": {
         "@inquirer/prompts": "^5.0.2",
+        "@npmcli/promise-spawn": "^7.0.2",
         "commander": "^11.1.0",
         "giget": "^1.2.3",
+        "ora": "^8.0.1",
         "semver": "^7.5.4"
     },
     "devDependencies": {
         "@types/commander": "*",
+        "@types/npmcli__promise-spawn": "^6.0.3",
         "ts-node": "*"
     }
 }

--- a/packages/@apphosting/create/package.json
+++ b/packages/@apphosting/create/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@apphosting/create",
-    "version": "0.3.0",
+    "version": "0.3.1",
     "main": "dist/index.js",
     "description": "Experimental addon to the Firebase CLI to add web framework support",
     "repository": {

--- a/packages/@apphosting/create/src/bin/create.ts
+++ b/packages/@apphosting/create/src/bin/create.ts
@@ -72,8 +72,8 @@ program
       );
       cloneSpinner.succeed();
       if (packageManager === "npm") {
-        console.log(`> ${packageManager} install`);
-        await spawn(packageManager, ["install"], {
+        console.log("> npm install");
+        await spawn("npm", ["install"], {
           shell: true,
           stdio: "inherit",
           cwd: dir,

--- a/packages/@apphosting/create/src/bin/create.ts
+++ b/packages/@apphosting/create/src/bin/create.ts
@@ -1,50 +1,88 @@
 #! /usr/bin/env node
-import { spawnSync, spawn } from "child_process";
 import { program } from "commander";
 import { downloadTemplate } from "giget";
 import { select } from "@inquirer/prompts";
+import spawn from "@npmcli/promise-spawn";
+import ora from "ora";
+
+console.log(process);
 
 program
   .option("--framework <string>")
+  .option("--package-manager <string>")
+  .option("--skip-install")
   .argument("<directory>", "path to the project's root directory")
-  .action(async (dir, { framework }: { framework?: string }) => {
-    // TODO validate the framework
-    if (!framework) {
-      framework = await select({
-        message: "Select a framework",
-        choices: [
-          { name: "Angular", value: "angular" },
-          { name: "Next.js", value: "nextjs" },
-        ],
-      });
-    }
-    // TODO allow different templates
-    await downloadTemplate(
-      `gh:FirebaseExtended/firebase-framework-tools/starters/${framework}/basic`,
-      { dir, force: true },
-    );
-    const packageManager = await select({
-      message: "Select a package manager",
-      default: "npm",
-      choices: [
-        { name: "npm", value: "npm" },
-        { name: "yarn", value: "yarn" },
-        { name: "pnpm", value: "pnpm" },
-      ],
+  .action(
+    async (
+      dir,
+      {
+        framework,
+        packageManager,
+        skipInstall,
+      }: { framework?: string; packageManager?: string; skipInstall?: true },
+    ) => {
+      // TODO DRY up the validation and error handling, move to commander parse
+      if (framework) {
+        if (!["angular", "nextjs"].includes(framework)) {
+          console.error(`Invalid framework: ${framework}, valid choices are angular and nextjs`);
+          process.exit(1);
+        }
+      } else {
+        framework = await select({
+          message: "Select a framework",
+          choices: [
+            { name: "Angular", value: "angular" },
+            { name: "Next.js", value: "nextjs" },
+          ],
+        });
+      }
+      const cloneSpinner = ora("Cloning template...").start();
+      // TODO allow different templates
+      await downloadTemplate(
+        `gh:FirebaseExtended/firebase-framework-tools/starters/${framework}/basic`,
+        { dir, force: true },
+      );
+      cloneSpinner.succeed();
+      // TODO DRY up validation and error message, move to commander parse
+      if (packageManager) {
+        if (!["npm", "yarn", "pnpm"].includes(packageManager)) {
+          console.error(
+            `Invalid package manager: ${packageManager}, valid choices are npm, yarn, and pnpm`,
+          );
+          process.exit(1);
+        }
+      } else {
+        packageManager = await select({
+          message: "Select a package manager",
+          default: "npm",
+          choices: [
+            { name: "npm", value: "npm" },
+            { name: "yarn", value: "yarn" },
+            { name: "pnpm", value: "pnpm" },
+          ],
+        });
+      }
+      if (packageManager !== "npm") {
+        await spawn("corepack", ["enable"], {
+          shell: true,
+          stdio: "inherit",
+          cwd: dir,
+        });
+        await spawn("corepack", ["use", `${packageManager}@*`], {
+          shell: true,
+          stdio: "inherit",
+          cwd: dir,
+        });
+      }
+      if (!skipInstall) {
+        const installSpinner = ora("Installing dependencies...").start();
+        await spawn(packageManager, ["install"], {
+          shell: true,
+          stdio: "inherit",
+          cwd: dir,
+        });
+        installSpinner.succeed();
+      }
     });
-    if (packageManager !== "npm") {
-      spawnSync("corepack", ["enable"]);
-      spawnSync("corepack", ["use", `${packageManager}@*`], {
-        shell: true,
-        stdio: "inherit",
-        cwd: dir,
-      });
-    }
-    spawn(packageManager, ["install"], {
-      shell: true,
-      stdio: "inherit",
-      cwd: dir,
-    });
-  });
 
 program.parse();

--- a/packages/@apphosting/create/src/bin/create.ts
+++ b/packages/@apphosting/create/src/bin/create.ts
@@ -83,6 +83,7 @@ program
         });
         installSpinner.succeed();
       }
-    });
+    },
+  );
 
 program.parse();

--- a/packages/@apphosting/create/src/bin/create.ts
+++ b/packages/@apphosting/create/src/bin/create.ts
@@ -4,6 +4,8 @@ import { downloadTemplate } from "giget";
 import { select, input } from "@inquirer/prompts";
 import spawn from "@npmcli/promise-spawn";
 import ora from "ora";
+import { rm } from "fs/promises";
+import { join } from "path";
 
 const contextIsNpmCreate = process.env.npm_command === "init";
 
@@ -96,6 +98,7 @@ program
           stdio: "inherit",
           cwd: directory,
         });
+        await rm(join(directory, "package-lock.json"));
       }
     },
   );

--- a/packages/create-next-on-firebase/package.json
+++ b/packages/create-next-on-firebase/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-next-on-firebase",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Experimental CLI to init a Next.js project for deployment on Firebase",
   "main": "dist/index.js",
   "bin": {
@@ -18,5 +18,15 @@
   "bugs": {
     "url": "https://github.com/FirebaseExtended/firebase-framework-tools/issues"
   },
-  "homepage": "https://github.com/FirebaseExtended/firebase-framework-tools#readme"
+  "homepage": "https://github.com/FirebaseExtended/firebase-framework-tools#readme",
+  "dependencies": {
+    "@npmcli/promise-spawn": "^7.0.2",
+    "commander": "^12.0.0",
+    "tslib": "^2.6.2"
+  },
+  "devDependencies": {
+      "@types/commander": "*",
+      "@types/npmcli__promise-spawn": "^6.0.3",
+      "typescript": "*"
+  }
 }

--- a/packages/create-next-on-firebase/package.json
+++ b/packages/create-next-on-firebase/package.json
@@ -20,7 +20,6 @@
   },
   "homepage": "https://github.com/FirebaseExtended/firebase-framework-tools#readme",
   "dependencies": {
-    "@inquirer/prompts": "^5.0.2",
     "@npmcli/promise-spawn": "^7.0.2",
     "commander": "^12.0.0",
     "tslib": "^2.6.2"

--- a/packages/create-next-on-firebase/package.json
+++ b/packages/create-next-on-firebase/package.json
@@ -1,10 +1,10 @@
 {
   "name": "create-next-on-firebase",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Experimental CLI to init a Next.js project for deployment on Firebase",
   "main": "dist/index.js",
   "bin": {
-    "create": "dist/bin/create.js"
+    "create-next-on-firebase": "dist/bin/create.js"
   },
   "scripts": {
     "build": "rm -rf dist && tsc && chmod +x ./dist/bin/*"

--- a/packages/create-next-on-firebase/package.json
+++ b/packages/create-next-on-firebase/package.json
@@ -1,8 +1,11 @@
 {
   "name": "create-next-on-firebase",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Experimental CLI to init a Next.js project for deployment on Firebase",
   "main": "dist/index.js",
+  "bin": {
+    "create": "dist/bin/create.js"
+  },
   "scripts": {
     "build": "rm -rf dist && tsc && chmod +x ./dist/bin/*"
   },

--- a/packages/create-next-on-firebase/package.json
+++ b/packages/create-next-on-firebase/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-next-on-firebase",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Experimental CLI to init a Next.js project for deployment on Firebase",
   "main": "dist/index.js",
   "bin": {

--- a/packages/create-next-on-firebase/package.json
+++ b/packages/create-next-on-firebase/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-next-on-firebase",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Experimental CLI to init a Next.js project for deployment on Firebase",
   "main": "dist/index.js",
   "bin": {
@@ -20,6 +20,7 @@
   },
   "homepage": "https://github.com/FirebaseExtended/firebase-framework-tools#readme",
   "dependencies": {
+    "@inquirer/prompts": "^5.0.2",
     "@npmcli/promise-spawn": "^7.0.2",
     "commander": "^12.0.0",
     "tslib": "^2.6.2"

--- a/packages/create-next-on-firebase/src/bin/create.ts
+++ b/packages/create-next-on-firebase/src/bin/create.ts
@@ -1,7 +1,6 @@
 #! /usr/bin/env node
 import { program } from "commander";
 import spawn from "@npmcli/promise-spawn";
-import { input } from "@inquirer/prompts";
 
 const contextIsNpmCreate = process.env.npm_command === "init";
 
@@ -15,10 +14,6 @@ const npmUserAgent = process.env.npm_config_user_agent
 program
   .argument("[directory]", "path to the project's root directory")
   .action(async (directory) => {
-    directory ||= await input({
-      message: "What directory should we bootstrap the application in?",
-      default: ".",
-    });
     let packageManager: string | undefined = undefined;
     if (contextIsNpmCreate) {
       packageManager = "npm";
@@ -28,15 +23,23 @@ program
       packageManager = "yarn";
     }
     if (packageManager) {
-      await spawn(packageManager, ["create", "@apphosting", "--framework=nextjs", directory], {
-        shell: true,
-        stdio: "inherit",
-      });
+      await spawn(
+        packageManager,
+        ["create", "@apphosting", "--framework=nextjs", directory].filter((it) => it),
+        {
+          shell: true,
+          stdio: "inherit",
+        },
+      );
     } else {
-      await spawn("npx", ["@apphosting/create", "--framework=nextjs", directory], {
-        shell: true,
-        stdio: "inherit",
-      });
+      await spawn(
+        "npx",
+        ["@apphosting/create", "--framework=nextjs", directory].filter((it) => it),
+        {
+          shell: true,
+          stdio: "inherit",
+        },
+      );
     }
   });
 

--- a/packages/create-next-on-firebase/src/bin/create.ts
+++ b/packages/create-next-on-firebase/src/bin/create.ts
@@ -1,33 +1,14 @@
 #! /usr/bin/env node
-import { spawn } from "node:child_process";
 import { program } from "commander";
+import spawn from "@npmcli/promise-spawn";
 
-program.argument("<directory>", "path to the project's root directory").action((directory) => {
-  console.log(`Shelling out to @apphosting/create:`);
-
-  const createProcess = spawn("npx", ["@apphosting/create", "--framework=nextjs", directory], {
-    shell: true,
-    stdio: "inherit",
+program
+  .argument("<directory>", "path to the project's root directory")
+  .action(async (directory) => {
+    await spawn("npx", ["@apphosting/create", "--framework=nextjs", directory], {
+      shell: true,
+      stdio: "inherit",
+    });
   });
-
-  // print out the shell command that spawn created
-  console.log(createProcess.spawnargs.at(-1));
-
-  createProcess.stdout?.on("data", (data) => {
-    console.log(`i: ${data}`);
-  });
-
-  createProcess.stderr?.on("data", (data) => {
-    console.error(`error: ${data}`);
-  });
-
-  createProcess.on("close", (code) => {
-    if (code === 0) {
-      console.log("Success!");
-    } else {
-      console.log(`There was a problem, exited with code ${code}`);
-    }
-  });
-});
 
 program.parse();

--- a/packages/create-next-on-firebase/src/bin/create.ts
+++ b/packages/create-next-on-firebase/src/bin/create.ts
@@ -15,32 +15,27 @@ program
   .argument("[directory]", "path to the project's root directory")
   .action(async (directory) => {
     let packageManager: string | undefined = undefined;
+    let packageManagerVersion = "*";
     if (contextIsNpmCreate) {
       packageManager = "npm";
     } else if (npmUserAgent.pnpm) {
       packageManager = "pnpm";
+      packageManagerVersion = npmUserAgent.pnpm;
     } else if (npmUserAgent.yarn) {
       packageManager = "yarn";
+      packageManagerVersion = npmUserAgent.yarn;
     }
+    const args = ["--yes", "@apphosting/create@latest", "--framework=nextjs"];
     if (packageManager) {
-      await spawn(
-        packageManager,
-        ["create", "@apphosting", "--framework=nextjs", directory].filter((it) => it),
-        {
-          shell: true,
-          stdio: "inherit",
-        },
-      );
-    } else {
-      await spawn(
-        "npx",
-        ["@apphosting/create", "--framework=nextjs", directory].filter((it) => it),
-        {
-          shell: true,
-          stdio: "inherit",
-        },
-      );
+      args.push(`--package-manager=${packageManager}@${packageManagerVersion}`);
     }
+    if (directory) {
+      args.push(directory);
+    }
+    await spawn("npx", args, {
+      shell: true,
+      stdio: "inherit",
+    });
   });
 
 program.parse();

--- a/packages/create-next-on-firebase/src/bin/create.ts
+++ b/packages/create-next-on-firebase/src/bin/create.ts
@@ -23,11 +23,10 @@ program
     if (contextIsNpmCreate) {
       packageManager = "npm";
     } else if (npmUserAgent.pnpm) {
-      packageManager = `pnpm@${npmUserAgent.pnpm}`;
+      packageManager = "pnpm";
     } else if (npmUserAgent.yarn) {
-      packageManager = `yarn@${npmUserAgent.yarn}`;
+      packageManager = "yarn";
     }
-    console.log(packageManager, ["create", "@apphosting", "--framework=nextjs", directory]);
     if (packageManager) {
       await spawn(packageManager, ["create", "@apphosting", "--framework=nextjs", directory], {
         shell: true,

--- a/packages/create-next-on-firebase/src/bin/create.ts
+++ b/packages/create-next-on-firebase/src/bin/create.ts
@@ -1,14 +1,44 @@
 #! /usr/bin/env node
 import { program } from "commander";
 import spawn from "@npmcli/promise-spawn";
+import { input } from "@inquirer/prompts";
+
+const contextIsNpmCreate = process.env.npm_command === "init";
+
+// npm/10.1.0 node/v20.9.0 darwin x64 workspaces/false
+// pnpm/9.1.0 npm/? node/v20.9.0 darwin x64
+// yarn/1.7.0 npm/? node/v8.9.4 darwin x64
+const npmUserAgent = process.env.npm_config_user_agent
+  ? Object.fromEntries(process.env.npm_config_user_agent.split(" ").map((s) => s.split("/")))
+  : {};
 
 program
-  .argument("<directory>", "path to the project's root directory")
+  .argument("[directory]", "path to the project's root directory")
   .action(async (directory) => {
-    await spawn("npx", ["@apphosting/create", "--framework=nextjs", directory], {
-      shell: true,
-      stdio: "inherit",
+    directory ||= await input({
+      message: "What directory should we bootstrap the application in?",
+      default: ".",
     });
+    let packageManager: string | undefined = undefined;
+    if (contextIsNpmCreate) {
+      packageManager = "npm";
+    } else if (npmUserAgent.pnpm) {
+      packageManager = `pnpm@${npmUserAgent.pnpm}`;
+    } else if (npmUserAgent.yarn) {
+      packageManager = `yarn@${npmUserAgent.yarn}`;
+    }
+    console.log(packageManager, ["create", "@apphosting", "--framework=nextjs", directory]);
+    if (packageManager) {
+      await spawn(packageManager, ["create", "@apphosting", "--framework=nextjs", directory], {
+        shell: true,
+        stdio: "inherit",
+      });
+    } else {
+      await spawn("npx", ["@apphosting/create", "--framework=nextjs", directory], {
+        shell: true,
+        stdio: "inherit",
+      });
+    }
   });
 
 program.parse();

--- a/starters/angular/basic/README.md
+++ b/starters/angular/basic/README.md
@@ -1,31 +1,21 @@
 # Angular on Firebase App Hosting
 
-This project was generated with [Angular CLI](https://github.com/angular/angular-cli) version 17.1.0-rc.0.
+## 1. Bootstrap your project
 
-## Development server
+```bash
+npm create @apphosting --framework=angular
+```
 
-Run `ng serve` for a dev server. Navigate to `http://localhost:4200/`. The application will automatically reload if you change any of the source files.
+## 2. Get your project setup on GitHub
 
-## Code scaffolding
+[Create a new repository on GitHub](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-new-repository) & follow the instructions to push the starter template. E.g,
 
-Run `ng generate component component-name` to generate a new component. You can also use `ng generate directive|pipe|service|class|guard|interface|enum|module`.
+<pre>
+git remote add origin https://github.com/<b>$YOUR_NEW_REPOSITORY</b>.git
+git branch -M main
+git push -u origin main
+</pre>
 
-## Build
+## 3. Setup Firebase App Hosting
 
-Run `ng build` to build the project. The build artifacts will be stored in the `dist/` directory.
-
-## Running unit tests
-
-Run `ng test` to execute the unit tests via [Karma](https://karma-runner.github.io).
-
-## Running end-to-end tests
-
-Run `ng e2e` to execute the end-to-end tests via a platform of your choice. To use this command, you need to first add a package that implements end-to-end testing capabilities.
-
-## Further help
-
-To get more help on the Angular CLI use `ng help` or go check out the [Angular CLI Overview and Command Reference](https://angular.io/cli) page.
-
-## Deploy to Firebase
-
-Run `firebase init hosting`, then `firebase deploy`.
+Continue the [Firebase App Hosting Getting Started guide](https://firebase.google.com/docs/app-hosting/get-started#step-1:).

--- a/starters/angular/basic/README.md
+++ b/starters/angular/basic/README.md
@@ -1,6 +1,20 @@
 # Angular on Firebase App Hosting
 
-## 1. Get your project setup on GitHub
+This is a boilerplate [Angular](https://angular.dev/) project to showcase SSG and SSR on [Firebase App Hosting](https://firebase.google.com/docs/app-hosting).
+
+## Getting Started
+
+Run the development server:
+
+```bash
+npm run start
+```
+
+Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+
+## Deploy to Firebase App Hosting
+
+### 1. Get your project setup on GitHub
 
 [Create a new GitHub repository](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-new-repository) and push the newly-initialized sample code to it. E.g,
 
@@ -10,6 +24,6 @@ git branch -M main
 git push -u origin main
 </pre>
 
-## 2. Setup Firebase App Hosting
+### 2. Setup Firebase App Hosting
 
 Continue the [Firebase App Hosting Getting Started guide](https://firebase.google.com/docs/app-hosting/get-started#step-1:).

--- a/starters/angular/basic/README.md
+++ b/starters/angular/basic/README.md
@@ -1,14 +1,8 @@
 # Angular on Firebase App Hosting
 
-## 1. Bootstrap your project
+## 1. Get your project setup on GitHub
 
-```bash
-npm create @apphosting --framework=angular
-```
-
-## 2. Get your project setup on GitHub
-
-[Create a new repository on GitHub](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-new-repository) & follow the instructions to push the starter template. E.g,
+[Create a new GitHub repository](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-new-repository) and push the newly-initialized sample code to it. E.g,
 
 <pre>
 git remote add origin https://github.com/<b>$YOUR_NEW_REPOSITORY</b>.git
@@ -16,6 +10,6 @@ git branch -M main
 git push -u origin main
 </pre>
 
-## 3. Setup Firebase App Hosting
+## 2. Setup Firebase App Hosting
 
 Continue the [Firebase App Hosting Getting Started guide](https://firebase.google.com/docs/app-hosting/get-started#step-1:).

--- a/starters/angular/basic/README.md
+++ b/starters/angular/basic/README.md
@@ -1,6 +1,6 @@
 # Angular on Firebase App Hosting
 
-This is a boilerplate [Angular](https://angular.dev/) project to showcase SSG and SSR on [Firebase App Hosting](https://firebase.google.com/docs/app-hosting).
+This is a boilerplate [Angular](https://angular.dev/) project to showcase SSG, SSR, and Deferrable Views on [Firebase App Hosting](https://firebase.google.com/docs/app-hosting).
 
 ## Getting Started
 
@@ -10,7 +10,7 @@ Run the development server:
 npm run start
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Open [http://localhost:4200](http://localhost:4200) with your browser to see the result.
 
 ## Deploy to Firebase App Hosting
 

--- a/starters/angular/basic/package-lock.json
+++ b/starters/angular/basic/package-lock.json
@@ -28,6 +28,7 @@
         "@angular-devkit/build-angular": "^17.3.1",
         "@angular/cli": "^17.3.1",
         "@angular/compiler-cli": "^17.3.1",
+        "@types/express": "^4.17.21",
         "@types/jasmine": "~5.1.0",
         "@types/uuid": "^9.0.8",
         "jasmine-core": "~5.1.0",

--- a/starters/angular/basic/package.json
+++ b/starters/angular/basic/package.json
@@ -31,6 +31,7 @@
     "@angular-devkit/build-angular": "^17.3.1",
     "@angular/cli": "^17.3.1",
     "@angular/compiler-cli": "^17.3.1",
+    "@types/express": "^4.17.21",
     "@types/jasmine": "~5.1.0",
     "@types/uuid": "^9.0.8",
     "jasmine-core": "~5.1.0",

--- a/starters/nextjs/basic/README.md
+++ b/starters/nextjs/basic/README.md
@@ -1,6 +1,20 @@
 # Next.js on Firebase App Hosting
 
-## 1. Get your project setup on GitHub
+This is a boilerplate [Next.js](https://nextjs.org/) project to showcase SSG, SSR and ISR on [Firebase App Hosting](https://firebase.google.com/docs/app-hosting).
+
+## Getting Started
+
+Run the development server:
+
+```bash
+npm run dev
+```
+
+Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+
+## Deploy to Firebase App Hosting
+
+### 1. Get your project setup on GitHub
 
 [Create a new GitHub repository](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-new-repository) and push the newly-initialized sample code to it. E.g,
 
@@ -10,6 +24,6 @@ git branch -M main
 git push -u origin main
 </pre>
 
-## 2. Setup Firebase App Hosting
+### 2. Setup Firebase App Hosting
 
 Continue the [Firebase App Hosting Getting Started guide](https://firebase.google.com/docs/app-hosting/get-started#step-1:).

--- a/starters/nextjs/basic/README.md
+++ b/starters/nextjs/basic/README.md
@@ -1,6 +1,6 @@
 # Next.js on Firebase App Hosting
 
-This is a boilerplate [Next.js](https://nextjs.org/) project to showcase SSG, SSR and ISR on [Firebase App Hosting](https://firebase.google.com/docs/app-hosting).
+This is a boilerplate [Next.js](https://nextjs.org/) project to showcase SSG, SSR, and ISR on [Firebase App Hosting](https://firebase.google.com/docs/app-hosting).
 
 ## Getting Started
 

--- a/starters/nextjs/basic/README.md
+++ b/starters/nextjs/basic/README.md
@@ -1,11 +1,15 @@
-This is a boilerplate [Next.js](https://nextjs.org/) project to showcase the SSG, SSR and ISR features on Firebase App Hosting.
+# Next.js on Firebase App Hosting
 
-## Getting Started
+## 1. Get your project setup on GitHub
 
-Run the development server:
+[Create a new GitHub repository](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-new-repository) and push the newly-initialized sample code to it. E.g,
 
-```bash
-npm run dev
-```
+<pre>
+git remote add origin https://github.com/<b>$YOUR_NEW_REPOSITORY</b>.git
+git branch -M main
+git push -u origin main
+</pre>
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+## 2. Setup Firebase App Hosting
+
+Continue the [Firebase App Hosting Getting Started guide](https://firebase.google.com/docs/app-hosting/get-started#step-1:).


### PR DESCRIPTION
* Add package-mananger choices to the NPX `@apphosting/create` script, if `npm|yarn|pnpm init|create @apphosting` is used don't prompt—use the package manager from the command
* Allow for interactive directory picking
* Wire up create-next-on-firebase so `npm init next-on-firebase` works appropriately
* Download the starters based off the chosen framework
* Add `@types/express` to the Angular starter
* READMEs for the starters
* Drop Node 16 from the tests as we're having engine issues & no longer support v16