### PR TITLE
fix SvelteKit server responses

### DIFF
--- a/packages/firebase-frameworks/src/sveltekit/index.ts
+++ b/packages/firebase-frameworks/src/sveltekit/index.ts
@@ -26,21 +26,11 @@ export const handle = async (req: Request, res: Response) => {
     return res.writeHead(404, "Not Found").end();
   }
 
-  let body;
-  const contentType = rendered.headers.get("Content-Type");
-  if (
-    contentType.startsWith("text/") ||
-    contentType.startsWith("application/json") ||
-    contentType.startsWith("application/xml") ||
-    contentType.startsWith("application/javascript") ||
-    contentType.startsWith("application/vnd.ms-excel")
-  ) {
-    body = await rendered.text();
-  } else {
-    body = Buffer.from(await rendered.arrayBuffer());
-  }
+  const body = (await rendered.arrayBuffer()) as ArrayBuffer;
 
-  return res.writeHead(rendered.status, Object.fromEntries(rendered.headers)).end(body);
+  return res
+    .writeHead(rendered.status, Object.fromEntries(rendered.headers))
+    .end(Buffer.from(body));
 };
 
 // https://github.com/jthegedus/svelte-adapter-firebase/blob/main/src/files/firebase-to-svelte-kit.js

--- a/packages/firebase-frameworks/src/sveltekit/index.ts
+++ b/packages/firebase-frameworks/src/sveltekit/index.ts
@@ -26,7 +26,7 @@ export const handle = async (req: Request, res: Response) => {
     return res.writeHead(404, "Not Found").end();
   }
 
-  const body = (await rendered.arrayBuffer()) as ArrayBuffer;
+  const body: ArrayBuffer = await rendered.arrayBuffer();
 
   return res
     .writeHead(rendered.status, Object.fromEntries(rendered.headers))


### PR DESCRIPTION
Fix SvelteKit server responses. Huge thanks to @m3tasploit for the initiative. This PR differs from #159 by always responding with a Buffer.

Created test deployments here:
- With this fix: https://fb-tools-dev--svelkite-buffer-test-9b25lhcv.web.app/
- With the current production server: https://fb-tools-dev--svelkite-buffer-test-prod-6sdoxhqh.web.app/

Click in the `request` buttons to test requests. Note that images are broken with the current production server.