### PR TITLE
Update @apphosting/common dependency in adapters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23511,7 +23511,7 @@
       "version": "17.2.5",
       "license": "Apache-2.0",
       "dependencies": {
-        "@apphosting/common": "^1.0.0",
+        "@apphosting/common": "^0.0.1",
         "firebase-functions": "^4.3.1",
         "fs-extra": "^11.1.1",
         "strip-ansi": "^7.1.0",
@@ -23609,7 +23609,7 @@
       "version": "14.0.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@apphosting/common": "^1.0.0",
+        "@apphosting/common": "^0.0.1",
         "fs-extra": "^11.1.1",
         "yaml": "^2.3.4"
       },
@@ -23708,7 +23708,7 @@
       }
     },
     "packages/@apphosting/common": {
-      "version": "1.0.0",
+      "version": "0.0.1",
       "license": "Apache-2.0"
     },
     "packages/@apphosting/create": {
@@ -24011,6 +24011,7 @@
     },
     "packages/create-next-on-firebase": {
       "version": "0.2.2",
+      "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@npmcli/promise-spawn": "^7.0.2",
@@ -24028,6 +24029,7 @@
     },
     "packages/firebase-frameworks": {
       "version": "0.11.3",
+      "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@hapi/accept": "^6.0.1",

--- a/packages/@apphosting/adapter-angular/package.json
+++ b/packages/@apphosting/adapter-angular/package.json
@@ -1,79 +1,79 @@
 {
-    "name": "@apphosting/adapter-angular",
-    "version": "17.2.5",
-    "main": "dist/index.js",
-    "description": "Experimental addon to the Firebase CLI to add web framework support",
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/FirebaseExtended/firebase-framework-tools.git"
+  "name": "@apphosting/adapter-angular",
+  "version": "17.2.5",
+  "main": "dist/index.js",
+  "description": "Experimental addon to the Firebase CLI to add web framework support",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/FirebaseExtended/firebase-framework-tools.git"
+  },
+  "bin": {
+    "apphosting-adapter-angular-build": "dist/bin/build.js",
+    "apphosting-adapter-angular-create": "dist/bin/create.js"
+  },
+  "author": {
+    "name": "Firebase",
+    "url": "https://firebase.google.com/"
+  },
+  "bugs": {
+    "url": "https://github.com/FirebaseExtended/firebase-framework-tools/issues"
+  },
+  "type": "module",
+  "sideEffects": false,
+  "scripts": {
+    "build": "rm -rf dist && tsc && chmod +x ./dist/bin/*",
+    "test": "ts-mocha -p tsconfig.json src/**/*.spec.ts",
+    "localregistry:start": "npx verdaccio --config ../publish-dev/verdaccio-config.yaml",
+    "localregistry:publish": "(npm view --registry=http://localhost:4873 @apphosting/adapter-angular && npm unpublish --@apphosting:registry=http://localhost:4873 --force); npm publish --@apphosting:registry=http://localhost:4873"
+  },
+  "exports": {
+    ".": {
+      "node": "./dist/index.js",
+      "default": null
     },
-    "bin": {
-        "apphosting-adapter-angular-build": "dist/bin/build.js",
-        "apphosting-adapter-angular-create": "dist/bin/create.js"
-    },
-    "author": {
-        "name": "Firebase",
-        "url": "https://firebase.google.com/"
-    },
-    "bugs": {
-        "url": "https://github.com/FirebaseExtended/firebase-framework-tools/issues"
-    },
-    "type": "module",
-    "sideEffects": false,
-    "scripts": {
-        "build": "rm -rf dist && tsc && chmod +x ./dist/bin/*",
-        "test": "ts-mocha -p tsconfig.json src/**/*.spec.ts",
-        "localregistry:start": "npx verdaccio --config ../publish-dev/verdaccio-config.yaml",
-        "localregistry:publish": "(npm view --registry=http://localhost:4873 @apphosting/adapter-angular && npm unpublish --@apphosting:registry=http://localhost:4873 --force); npm publish --@apphosting:registry=http://localhost:4873"
-    },
-    "exports": {
-        ".": {
-            "node": "./dist/index.js",
-            "default": null
-        },
-        "./dist/*": {
-            "node": "./dist/*",
-            "default": null
-        }
-    },
-    "files": [
-        "dist"
-    ],
-    "license": "Apache-2.0",
-    "dependencies": {
-        "@apphosting/common": "^1.0.0",
-        "firebase-functions": "^4.3.1",
-        "fs-extra": "^11.1.1",
-        "strip-ansi": "^7.1.0",
-        "tslib": "^2.3.1",
-        "yaml": "^2.3.4",
-        "zod": "^3.22.4"
-    },
-    "peerDependencies": {
-        "@angular-devkit/architect": "~0.1702.0",
-        "@angular-devkit/core": "~17.2.0"
-    },
-    "peerDependenciesMeta": {
-        "@angular-devkit/architect": {
-            "optional": true
-        },
-        "@angular-devkit/core": {
-            "optional": true
-        }
-    },
-    "devDependencies": {
-        "@angular-devkit/architect": "~0.1702.0",
-        "@angular-devkit/core": "~17.2.0",
-        "@angular/core": "~17.2.0",
-        "@types/fs-extra": "*",
-        "@types/mocha": "*",
-        "@types/tmp": "*",
-        "mocha": "*",
-        "semver": "*",
-        "tmp": "*",
-        "ts-mocha": "*",
-        "ts-node": "*",
-        "typescript": "*",
-        "verdaccio": "^5.30.3"
+    "./dist/*": {
+      "node": "./dist/*",
+      "default": null
     }
+  },
+  "files": [
+    "dist"
+  ],
+  "license": "Apache-2.0",
+  "dependencies": {
+    "@apphosting/common": "^0.0.1",
+    "firebase-functions": "^4.3.1",
+    "fs-extra": "^11.1.1",
+    "strip-ansi": "^7.1.0",
+    "tslib": "^2.3.1",
+    "yaml": "^2.3.4",
+    "zod": "^3.22.4"
+  },
+  "peerDependencies": {
+    "@angular-devkit/architect": "~0.1702.0",
+    "@angular-devkit/core": "~17.2.0"
+  },
+  "peerDependenciesMeta": {
+    "@angular-devkit/architect": {
+      "optional": true
+    },
+    "@angular-devkit/core": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@angular-devkit/architect": "~0.1702.0",
+    "@angular-devkit/core": "~17.2.0",
+    "@angular/core": "~17.2.0",
+    "@types/fs-extra": "*",
+    "@types/mocha": "*",
+    "@types/tmp": "*",
+    "mocha": "*",
+    "semver": "*",
+    "tmp": "*",
+    "ts-mocha": "*",
+    "ts-node": "*",
+    "typescript": "*",
+    "verdaccio": "^5.30.3"
+  }
 }

--- a/packages/@apphosting/adapter-nextjs/package.json
+++ b/packages/@apphosting/adapter-nextjs/package.json
@@ -41,7 +41,7 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "@apphosting/common": "^1.0.0",
+    "@apphosting/common": "^0.0.1",
     "fs-extra": "^11.1.1",
     "yaml": "^2.3.4"
   },


### PR DESCRIPTION
The only thing that's changing in the Angular adapter's package.json is the @apphosting/common dependency - there's just some weirdness going on with the formatter that's setting it back to 2 space from 4.