### PR TITLE
Include dependencies and dependents when scoping build command for releases

### DIFF
--- a/scripts/github.js
+++ b/scripts/github.js
@@ -1,6 +1,5 @@
 #! /usr/bin/env node
 const { execSync } = require("child_process");
-const { basename } = require("path");
 
 const [, packageFromRef, versionFromRef, , prerelease] =
   /^refs\/tags\/(.+)-v(\d\d*\.\d\d*(\.\d\d*)?(-.+)?)$/.exec(process.env.GITHUB_REF ?? "") ?? [];
@@ -13,7 +12,9 @@ const since = process.env.GITHUB_ACTION
 
 const lernaList = JSON.parse(
   execSync(
-    `lerna list --json --include-dependencies --include-dependents ${packageFromRef ? "" : since}`,
+    `lerna list --json --include-dependencies ${
+      packageFromRef ? `--scope={,*/}${packageFromRef}` : since
+    }`,
     { stdio: ["ignore", "pipe", "ignore"] },
   ).toString(),
 );
@@ -23,7 +24,6 @@ const shortSHA = execSync(`git rev-parse --short ${ref}`).toString().trim();
 
 const filteredLernaList = lernaList.filter((lerna) => {
   if (lerna.private) return false;
-  if (packageFromRef && packageFromRef !== basename(lerna.location)) return false;
   return true;
 });
 

--- a/scripts/github.js
+++ b/scripts/github.js
@@ -12,7 +12,7 @@ const since = process.env.GITHUB_ACTION
 
 const lernaList = JSON.parse(
   execSync(
-    `lerna list --json --include-dependencies ${
+    `lerna list --json --include-dependencies --include-dependents ${
       packageFromRef ? `--scope={,*/}${packageFromRef}` : since
     }`,
     { stdio: ["ignore", "pipe", "ignore"] },


### PR DESCRIPTION
https://github.com/FirebaseExtended/firebase-framework-tools/pull/220 includes dependencies for PRs, but not for releases. We were subtly filtering out all packages from the build except for the package targeted for releases, resulting in failed pre-release builds for the framework adapters that now depend on @apphosting/common.