### PR TITLE
Remove LOCAL flag to fix deployment on Cloud Run

### DIFF
--- a/starters/angular/basic/server.ts
+++ b/starters/angular/basic/server.ts
@@ -53,8 +53,4 @@ function run(): void {
   });
 }
 
-// Note: The express server is started by Firebase automatically.
-if (process.env['LOCAL']) {
-  run();
-}
-
+run();


### PR DESCRIPTION
From https://firebase.google.com/docs/app-hosting/get-started

We found the Cloud Run service is failing with the following error message:

> The user-provided container failed to start and listen on the port defined provided by the PORT=8080 environment variable

Because it doesn't have the LOCA=true variable

Removing this, fix the issue, not sure if you want to accept this PR, or if you would like to inject the `LOCAL=true` variable on the deployment process. 