### PR TITLE
Update sharp version

### DIFF
--- a/packages/firebase-frameworks/package.json
+++ b/packages/firebase-frameworks/package.json
@@ -55,7 +55,7 @@
   "peerDependencies": {
     "firebase": "^9.9.0 || ^10.0.0",
     "firebase-admin": "^11.0.1 || ^12.0.0",
-    "sharp": "^0.32.1"
+    "sharp": "^0.33.4"
   },
   "peerDependenciesMeta": {
     "firebase": {

--- a/packages/firebase-frameworks/package.json
+++ b/packages/firebase-frameworks/package.json
@@ -55,7 +55,7 @@
   "peerDependencies": {
     "firebase": "^9.9.0 || ^10.0.0",
     "firebase-admin": "^11.0.1 || ^12.0.0",
-    "sharp": "^0.33.4"
+    "sharp": "^0.32 || ^0.33"
   },
   "peerDependenciesMeta": {
     "firebase": {


### PR DESCRIPTION
The current sharp peer dependency is out of date. If you're trying to deploy a function that would use sharp, the deploy errors because there's a version mismatch. This is because SEMVER < 1 counts minor releases (0.xx) as potentially breaking, so `0.32` won't resolve with `0.33.x` installed