### PR TITLE
Use incomingMessageFromExpress function in express request handler

### DIFF
--- a/packages/firebase-frameworks/src/express/index.ts
+++ b/packages/firebase-frameworks/src/express/index.ts
@@ -1,10 +1,13 @@
 import { pathToFileURL } from "url";
 import type { Request } from "firebase-functions/v2/https";
 import type { Response } from "express";
+import { incomingMessageFromExpress } from "../utils.js";
 
 const express = import(`${pathToFileURL(process.cwd())}/bootstrap.js`);
 
 export const handle = async (req: Request, res: Response) => {
   const { handle } = await express;
-  handle(req, res);
+  const incomingMessage = incomingMessageFromExpress(req);
+
+  handle(incomingMessage, res);
 };


### PR DESCRIPTION
- Use the `incomingMessageFromExpress` function in the express request handler (used by Astro handler) in order to create a Node.js HTTP server’s incoming message object from an Express Request object.
- Fixes [#7446](https://github.com/firebase/firebase-tools/issues/7446) and [#7046](https://github.com/firebase/firebase-tools/issues/7046) where multipart/form-data stream was exhausted before making it to the application api endpoint causing an error when trying to read the stream again.