### PR TITLE
Add single quotes to --scope arg value in lerna list command

### DIFF
--- a/scripts/github.js
+++ b/scripts/github.js
@@ -13,7 +13,7 @@ const since = process.env.GITHUB_ACTION
 const lernaList = JSON.parse(
   execSync(
     `lerna list --json --include-dependencies --include-dependents ${
-      packageFromRef ? `--scope={,*/}${packageFromRef}` : since
+      packageFromRef ? `--scope='{,*/}${packageFromRef}'` : since
     }`,
     { stdio: ["ignore", "pipe", "ignore"] },
   ).toString(),


### PR DESCRIPTION
Fixes an error on the ci process when running the build script that prevents the firebase-frameworks release to be published.