### PR TITLE
Fix apphosting/common in build/publish

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,8 +6,8 @@
     "": {
       "name": "root",
       "workspaces": [
-        "packages/@apphosting/*",
-        "packages/create-next-on-firebase/*",
+        "packages/@apphosting/**",
+        "packages/create-next-on-firebase",
         "packages/firebase-frameworks"
       ],
       "devDependencies": {
@@ -8827,6 +8827,80 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
+    "node_modules/@rollup/plugin-json": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-6.1.0.tgz",
+      "integrity": "sha512-EGI2te5ENk1coGeADSIwZ7G2Q8CJS2sF120T7jLw4xFw9n7wIOXHo+kIYRAoVpJAN+kmqZSoO3Fp4JtoNF4ReA==",
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-node-resolve": {
+      "version": "15.2.3",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.2.3.tgz",
+      "integrity": "sha512-j/lym8nf5E21LwBT4Df1VD6hRO2L2iwUeUmP7litikRsVp1H6NWx20NEp0Y7su+7XGc476GnXXc4kFeZNGmaSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "@types/resolve": "1.20.2",
+        "deepmerge": "^4.2.2",
+        "is-builtin-module": "^3.2.1",
+        "is-module": "^1.0.0",
+        "resolve": "^1.22.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.78.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/pluginutils": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.0.tgz",
+      "integrity": "sha512-XTIWOPPcpvyKI6L1NHo0lFlCyznUEyPmPY1mc3KpPVDYulHSTvyeLNVW00QTLIAFNhR3kYnJTQHeGqU4M3n09g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/pluginutils/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "license": "MIT"
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.9.6",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.9.6.tgz",
@@ -8892,6 +8966,19 @@
         "linux"
       ]
     },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.21.2.tgz",
+      "integrity": "sha512-flOcGHDZajGKYpLV0JNc0VFH361M7rnV1ee+NTeC/BQQ1/0pllYcFmxpagltANYt8FYf9+kL6RSk80Ziwyhr7w==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.9.6",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.9.6.tgz",
@@ -8918,6 +9005,19 @@
         "linux"
       ]
     },
+    "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.21.2.tgz",
+      "integrity": "sha512-cZdyuInj0ofc7mAQpKcPR2a2iu4YM4FQfuUzCVA2u4HI95lCwzjoPtdWjdpDKyHxI0UO82bLDoOaLfpZ/wviyQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.9.6",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.9.6.tgz",
@@ -8926,6 +9026,19 @@
         "riscv64"
       ],
       "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.21.2.tgz",
+      "integrity": "sha512-PMxkrWS9z38bCr3rWvDFVGD6sFeZJw4iQlhrup7ReGmfn7Oukrr/zweLhYX6v2/8J6Cep9IEA/SmjXjCmSbrMQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -9528,8 +9641,7 @@
     "node_modules/@types/estree": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
-      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
-      "dev": true
+      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw=="
     },
     "node_modules/@types/express": {
       "version": "4.17.3",
@@ -9800,6 +9912,13 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ=="
+    },
+    "node_modules/@types/resolve": {
+      "version": "1.20.2",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
+      "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/retry": {
       "version": "0.12.0",
@@ -12804,6 +12923,10 @@
         }
       }
     },
+    "node_modules/create-next-on-firebase": {
+      "resolved": "packages/create-next-on-firebase",
+      "link": true
+    },
     "node_modules/create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
@@ -14943,7 +15066,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -16277,6 +16399,13 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
       "integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ=="
+    },
+    "node_modules/is-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+      "integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-number": {
       "version": "7.0.0",
@@ -20431,7 +20560,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
       "engines": {
         "node": ">=8.6"
       },
@@ -21928,7 +22056,7 @@
       "version": "3.29.4",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.4.tgz",
       "integrity": "sha512-oWzmBZwvYrU0iJHtDmhsm662rC15FRXmcjCk1xD771dFDx5jJ02ufAQQTn0etB2emNk4J9EZg/yWKpsn9BWGRw==",
-      "dev": true,
+      "devOptional": true,
       "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -21940,6 +22068,96 @@
       "optionalDependencies": {
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/rollup-plugin-commonjs": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-commonjs/-/rollup-plugin-commonjs-10.1.0.tgz",
+      "integrity": "sha512-jlXbjZSQg8EIeAAvepNwhJj++qJWNJw1Cl0YnOqKtP5Djx+fFGkp3WRh+W0ASCaFG5w1jhmzDxgu3SJuVxPF4Q==",
+      "deprecated": "This package has been deprecated and is no longer maintained. Please use @rollup/plugin-commonjs.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "estree-walker": "^0.6.1",
+        "is-reference": "^1.1.2",
+        "magic-string": "^0.25.2",
+        "resolve": "^1.11.0",
+        "rollup-pluginutils": "^2.8.1"
+      },
+      "peerDependencies": {
+        "rollup": ">=1.12.0"
+      }
+    },
+    "node_modules/rollup-plugin-commonjs/node_modules/estree-walker": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
+      "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rollup-plugin-commonjs/node_modules/is-reference": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
+      "integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/rollup-plugin-commonjs/node_modules/magic-string": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sourcemap-codec": "^1.4.8"
+      }
+    },
+    "node_modules/rollup-plugin-node-resolve": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-5.2.0.tgz",
+      "integrity": "sha512-jUlyaDXts7TW2CqQ4GaO5VJ4PwwaV8VUGA7+km3n6k6xtOEacf61u0VXwN80phY/evMcaS+9eIeJ9MOyDxt5Zw==",
+      "deprecated": "This package has been deprecated and is no longer maintained. Please use @rollup/plugin-node-resolve.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/resolve": "0.0.8",
+        "builtin-modules": "^3.1.0",
+        "is-module": "^1.0.0",
+        "resolve": "^1.11.1",
+        "rollup-pluginutils": "^2.8.1"
+      },
+      "peerDependencies": {
+        "rollup": ">=1.11.0"
+      }
+    },
+    "node_modules/rollup-plugin-node-resolve/node_modules/@types/resolve": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.8.tgz",
+      "integrity": "sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/rollup-pluginutils": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
+      "integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "estree-walker": "^0.6.1"
+      }
+    },
+    "node_modules/rollup-pluginutils/node_modules/estree-walker": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
+      "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/run-applescript": {
       "version": "5.0.0",
@@ -22743,6 +22961,10 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/simple-server": {
+      "resolved": "packages/@apphosting/adapter-angular/src/simple-server",
+      "link": true
+    },
     "node_modules/simple-swizzle": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
@@ -22926,6 +23148,14 @@
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
       }
+    },
+    "node_modules/sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "deprecated": "Please use @jridgewell/sourcemap-codec instead",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/spdx-correct": {
       "version": "3.2.0",
@@ -25600,10 +25830,10 @@
       }
     },
     "packages/@apphosting/adapter-angular": {
-      "version": "17.2.7",
+      "version": "17.2.8",
       "license": "Apache-2.0",
       "dependencies": {
-        "@apphosting/common": "^0.0.2",
+        "@apphosting/common": "*",
         "firebase-functions": "^4.3.1",
         "fs-extra": "^11.1.1",
         "strip-ansi": "^7.1.0",
@@ -25665,6 +25895,175 @@
       "integrity": "sha512-ab+vq1ntGo1YoKvyYRptkQt3QE86dg+tSZYFSCt9ovEtFjV/zepOGW8hvhnWLpNGErcyE7f2cExySOiLZW/ZPQ==",
       "license": "Apache-2.0"
     },
+    "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.21.2.tgz",
+      "integrity": "sha512-fSuPrt0ZO8uXeS+xP3b+yYTCBUd05MoSp2N/MFOgjhhUhMmchXlpTQrTpI8T+YAwAQuK7MafsCOxW7VrPMrJcg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.21.2.tgz",
+      "integrity": "sha512-xGU5ZQmPlsjQS6tzTTGwMsnKUtu0WVbl0hYpTPauvbRAnmIvpInhJtgjj3mcuJpEiuUw4v1s4BimkdfDWlh7gA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.21.2.tgz",
+      "integrity": "sha512-99AhQ3/ZMxU7jw34Sq8brzXqWH/bMnf7ZVhvLk9QU2cOepbQSVTns6qoErJmSiAvU3InRqC2RRZ5ovh1KN0d0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.21.2.tgz",
+      "integrity": "sha512-ZbRaUvw2iN/y37x6dY50D8m2BnDbBjlnMPotDi/qITMJ4sIxNY33HArjikDyakhSv0+ybdUxhWxE6kTI4oX26w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.21.2.tgz",
+      "integrity": "sha512-ztRJJMiE8nnU1YFcdbd9BcH6bGWG1z+jP+IPW2oDUAPxPjo9dverIOyXz76m6IPA6udEL12reYeLojzW2cYL7w==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.21.2.tgz",
+      "integrity": "sha512-69CF19Kp3TdMopyteO/LJbWufOzqqXzkrv4L2sP8kfMaAQ6iwky7NoXTp7bD6/irKgknDKM0P9E/1l5XxVQAhw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.21.2.tgz",
+      "integrity": "sha512-48pD/fJkTiHAZTnZwR0VzHrao70/4MlzJrq0ZsILjLW/Ab/1XlVUStYyGt7tdyIiVSlGZbnliqmult/QGA2O2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.21.2.tgz",
+      "integrity": "sha512-RL56JMT6NwQ0lXIQmMIWr1SW28z4E4pOhRRNqwWZeXpRlykRIlEpSWdsgNWJbYBEWD84eocjSGDu/XxbYeCmwg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.21.2.tgz",
+      "integrity": "sha512-B90tYAUoLhU22olrafY3JQCFLnT3NglazdwkHyxNDYF/zAxJt5fJUB/yBoWFoIQ7SQj+KLe3iL4BhOMa9fzgpw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.21.2.tgz",
+      "integrity": "sha512-7twFizNXudESmC9oneLGIUmoHiiLppz/Xs5uJQ4ShvE6234K0VB1/aJYU3f/4g7PhssLGKBVCC37uRkkOi8wjg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.21.2.tgz",
+      "integrity": "sha512-9rRero0E7qTeYf6+rFh3AErTNU1VCQg2mn7CQcI44vNUWM9Ze7MSRS/9RFuSsox+vstRt97+x3sOhEey024FRQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.21.2.tgz",
+      "integrity": "sha512-5rA4vjlqgrpbFVVHX3qkrCo/fZTj1q0Xxpg+Z7yIo3J2AilW7t2+n6Q8Jrx+4MrYpAnjttTYF8rr7bP46BPzRw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.21.2.tgz",
+      "integrity": "sha512-6UUxd0+SKomjdzuAcp+HAmxw1FlGBnl1v2yEPSabtx4lBfdXHDVsW7+lQkgz9cNFJGY3AWR7+V8P5BqkD9L9nA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "packages/@apphosting/adapter-angular/node_modules/ansi-regex": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
@@ -25674,6 +26073,41 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "packages/@apphosting/adapter-angular/node_modules/rollup": {
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.21.2.tgz",
+      "integrity": "sha512-e3TapAgYf9xjdLvKQCkQTnbTKd4a6jwlpQSJJFokHGaX2IVjoEqkIIhiQfqsi0cdwlOD+tQGuOd5AJkc5RngBw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.5"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.21.2",
+        "@rollup/rollup-android-arm64": "4.21.2",
+        "@rollup/rollup-darwin-arm64": "4.21.2",
+        "@rollup/rollup-darwin-x64": "4.21.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.21.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.21.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.21.2",
+        "@rollup/rollup-linux-arm64-musl": "4.21.2",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.21.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.21.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.21.2",
+        "@rollup/rollup-linux-x64-gnu": "4.21.2",
+        "@rollup/rollup-linux-x64-musl": "4.21.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.21.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.21.2",
+        "@rollup/rollup-win32-x64-msvc": "4.21.2",
+        "fsevents": "~2.3.2"
       }
     },
     "packages/@apphosting/adapter-angular/node_modules/strip-ansi": {
@@ -25691,7 +26125,6 @@
       }
     },
     "packages/@apphosting/adapter-angular/src/simple-server": {
-      "extraneous": true,
       "dependencies": {
         "@rollup/plugin-json": "^6.1.0",
         "express": "^4.18.2",
@@ -25704,10 +26137,10 @@
       }
     },
     "packages/@apphosting/adapter-nextjs": {
-      "version": "14.0.6",
+      "version": "14.0.7",
       "license": "Apache-2.0",
       "dependencies": {
-        "@apphosting/common": "^0.0.2",
+        "@apphosting/common": "*",
         "fs-extra": "^11.1.1",
         "yaml": "^2.3.4"
       },
@@ -26115,7 +26548,6 @@
     },
     "packages/create-next-on-firebase": {
       "version": "0.2.2",
-      "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@npmcli/promise-spawn": "^7.0.2",
@@ -26129,6 +26561,51 @@
         "@types/commander": "*",
         "@types/npmcli__promise-spawn": "^6.0.3",
         "typescript": "*"
+      }
+    },
+    "packages/create-next-on-firebase/node_modules/@npmcli/promise-spawn": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-7.0.2.tgz",
+      "integrity": "sha512-xhfYPXoV5Dy4UkY0D+v2KkwvnDfiA/8Mt3sWCGI/hM03NsYIH8ZaG6QzS9x7pje5vHZBZJ2v6VRFVTWACnqcmQ==",
+      "license": "ISC",
+      "dependencies": {
+        "which": "^4.0.0"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "packages/create-next-on-firebase/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/create-next-on-firebase/node_modules/isexe": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
+      "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "packages/create-next-on-firebase/node_modules/which": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
+      "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^3.1.1"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^16.13.0 || >=18.0.0"
       }
     },
     "packages/firebase-frameworks": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "root",
       "workspaces": [
-        "packages/@apphosting/**",
+        "packages/@apphosting/*",
         "packages/create-next-on-firebase",
         "packages/firebase-frameworks"
       ],
@@ -8827,80 +8827,6 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
-    "node_modules/@rollup/plugin-json": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-6.1.0.tgz",
-      "integrity": "sha512-EGI2te5ENk1coGeADSIwZ7G2Q8CJS2sF120T7jLw4xFw9n7wIOXHo+kIYRAoVpJAN+kmqZSoO3Fp4JtoNF4ReA==",
-      "license": "MIT",
-      "dependencies": {
-        "@rollup/pluginutils": "^5.1.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "rollup": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@rollup/plugin-node-resolve": {
-      "version": "15.2.3",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.2.3.tgz",
-      "integrity": "sha512-j/lym8nf5E21LwBT4Df1VD6hRO2L2iwUeUmP7litikRsVp1H6NWx20NEp0Y7su+7XGc476GnXXc4kFeZNGmaSQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rollup/pluginutils": "^5.0.1",
-        "@types/resolve": "1.20.2",
-        "deepmerge": "^4.2.2",
-        "is-builtin-module": "^3.2.1",
-        "is-module": "^1.0.0",
-        "resolve": "^1.22.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^2.78.0||^3.0.0||^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "rollup": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@rollup/pluginutils": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.0.tgz",
-      "integrity": "sha512-XTIWOPPcpvyKI6L1NHo0lFlCyznUEyPmPY1mc3KpPVDYulHSTvyeLNVW00QTLIAFNhR3kYnJTQHeGqU4M3n09g==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "^1.0.0",
-        "estree-walker": "^2.0.2",
-        "picomatch": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "rollup": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@rollup/pluginutils/node_modules/estree-walker": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-      "license": "MIT"
-    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.9.6",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.9.6.tgz",
@@ -8966,19 +8892,6 @@
         "linux"
       ]
     },
-    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.21.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.21.2.tgz",
-      "integrity": "sha512-flOcGHDZajGKYpLV0JNc0VFH361M7rnV1ee+NTeC/BQQ1/0pllYcFmxpagltANYt8FYf9+kL6RSk80Ziwyhr7w==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.9.6",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.9.6.tgz",
@@ -9005,19 +8918,6 @@
         "linux"
       ]
     },
-    "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.21.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.21.2.tgz",
-      "integrity": "sha512-cZdyuInj0ofc7mAQpKcPR2a2iu4YM4FQfuUzCVA2u4HI95lCwzjoPtdWjdpDKyHxI0UO82bLDoOaLfpZ/wviyQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.9.6",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.9.6.tgz",
@@ -9026,19 +8926,6 @@
         "riscv64"
       ],
       "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.21.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.21.2.tgz",
-      "integrity": "sha512-PMxkrWS9z38bCr3rWvDFVGD6sFeZJw4iQlhrup7ReGmfn7Oukrr/zweLhYX6v2/8J6Cep9IEA/SmjXjCmSbrMQ==",
-      "cpu": [
-        "s390x"
-      ],
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -9641,7 +9528,8 @@
     "node_modules/@types/estree": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
-      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw=="
+      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+      "dev": true
     },
     "node_modules/@types/express": {
       "version": "4.17.3",
@@ -9912,13 +9800,6 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ=="
-    },
-    "node_modules/@types/resolve": {
-      "version": "1.20.2",
-      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
-      "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/retry": {
       "version": "0.12.0",
@@ -15066,6 +14947,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -16399,13 +16281,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
       "integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ=="
-    },
-    "node_modules/is-module": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
-      "integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/is-number": {
       "version": "7.0.0",
@@ -20560,6 +20435,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
       "engines": {
         "node": ">=8.6"
       },
@@ -22056,7 +21932,7 @@
       "version": "3.29.4",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.4.tgz",
       "integrity": "sha512-oWzmBZwvYrU0iJHtDmhsm662rC15FRXmcjCk1xD771dFDx5jJ02ufAQQTn0etB2emNk4J9EZg/yWKpsn9BWGRw==",
-      "devOptional": true,
+      "dev": true,
       "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -22068,96 +21944,6 @@
       "optionalDependencies": {
         "fsevents": "~2.3.2"
       }
-    },
-    "node_modules/rollup-plugin-commonjs": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-commonjs/-/rollup-plugin-commonjs-10.1.0.tgz",
-      "integrity": "sha512-jlXbjZSQg8EIeAAvepNwhJj++qJWNJw1Cl0YnOqKtP5Djx+fFGkp3WRh+W0ASCaFG5w1jhmzDxgu3SJuVxPF4Q==",
-      "deprecated": "This package has been deprecated and is no longer maintained. Please use @rollup/plugin-commonjs.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "estree-walker": "^0.6.1",
-        "is-reference": "^1.1.2",
-        "magic-string": "^0.25.2",
-        "resolve": "^1.11.0",
-        "rollup-pluginutils": "^2.8.1"
-      },
-      "peerDependencies": {
-        "rollup": ">=1.12.0"
-      }
-    },
-    "node_modules/rollup-plugin-commonjs/node_modules/estree-walker": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
-      "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/rollup-plugin-commonjs/node_modules/is-reference": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
-      "integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "*"
-      }
-    },
-    "node_modules/rollup-plugin-commonjs/node_modules/magic-string": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
-      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sourcemap-codec": "^1.4.8"
-      }
-    },
-    "node_modules/rollup-plugin-node-resolve": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-5.2.0.tgz",
-      "integrity": "sha512-jUlyaDXts7TW2CqQ4GaO5VJ4PwwaV8VUGA7+km3n6k6xtOEacf61u0VXwN80phY/evMcaS+9eIeJ9MOyDxt5Zw==",
-      "deprecated": "This package has been deprecated and is no longer maintained. Please use @rollup/plugin-node-resolve.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/resolve": "0.0.8",
-        "builtin-modules": "^3.1.0",
-        "is-module": "^1.0.0",
-        "resolve": "^1.11.1",
-        "rollup-pluginutils": "^2.8.1"
-      },
-      "peerDependencies": {
-        "rollup": ">=1.11.0"
-      }
-    },
-    "node_modules/rollup-plugin-node-resolve/node_modules/@types/resolve": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.8.tgz",
-      "integrity": "sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/rollup-pluginutils": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
-      "integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "estree-walker": "^0.6.1"
-      }
-    },
-    "node_modules/rollup-pluginutils/node_modules/estree-walker": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
-      "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/run-applescript": {
       "version": "5.0.0",
@@ -22961,10 +22747,6 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
-    "node_modules/simple-server": {
-      "resolved": "packages/@apphosting/adapter-angular/src/simple-server",
-      "link": true
-    },
     "node_modules/simple-swizzle": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
@@ -23148,14 +22930,6 @@
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
       }
-    },
-    "node_modules/sourcemap-codec": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
-      "deprecated": "Please use @jridgewell/sourcemap-codec instead",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/spdx-correct": {
       "version": "3.2.0",
@@ -25895,175 +25669,6 @@
       "integrity": "sha512-ab+vq1ntGo1YoKvyYRptkQt3QE86dg+tSZYFSCt9ovEtFjV/zepOGW8hvhnWLpNGErcyE7f2cExySOiLZW/ZPQ==",
       "license": "Apache-2.0"
     },
-    "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.21.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.21.2.tgz",
-      "integrity": "sha512-fSuPrt0ZO8uXeS+xP3b+yYTCBUd05MoSp2N/MFOgjhhUhMmchXlpTQrTpI8T+YAwAQuK7MafsCOxW7VrPMrJcg==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.21.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.21.2.tgz",
-      "integrity": "sha512-xGU5ZQmPlsjQS6tzTTGwMsnKUtu0WVbl0hYpTPauvbRAnmIvpInhJtgjj3mcuJpEiuUw4v1s4BimkdfDWlh7gA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.21.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.21.2.tgz",
-      "integrity": "sha512-99AhQ3/ZMxU7jw34Sq8brzXqWH/bMnf7ZVhvLk9QU2cOepbQSVTns6qoErJmSiAvU3InRqC2RRZ5ovh1KN0d0Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.21.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.21.2.tgz",
-      "integrity": "sha512-ZbRaUvw2iN/y37x6dY50D8m2BnDbBjlnMPotDi/qITMJ4sIxNY33HArjikDyakhSv0+ybdUxhWxE6kTI4oX26w==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.21.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.21.2.tgz",
-      "integrity": "sha512-ztRJJMiE8nnU1YFcdbd9BcH6bGWG1z+jP+IPW2oDUAPxPjo9dverIOyXz76m6IPA6udEL12reYeLojzW2cYL7w==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.21.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.21.2.tgz",
-      "integrity": "sha512-69CF19Kp3TdMopyteO/LJbWufOzqqXzkrv4L2sP8kfMaAQ6iwky7NoXTp7bD6/irKgknDKM0P9E/1l5XxVQAhw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.21.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.21.2.tgz",
-      "integrity": "sha512-48pD/fJkTiHAZTnZwR0VzHrao70/4MlzJrq0ZsILjLW/Ab/1XlVUStYyGt7tdyIiVSlGZbnliqmult/QGA2O2w==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.21.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.21.2.tgz",
-      "integrity": "sha512-RL56JMT6NwQ0lXIQmMIWr1SW28z4E4pOhRRNqwWZeXpRlykRIlEpSWdsgNWJbYBEWD84eocjSGDu/XxbYeCmwg==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.21.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.21.2.tgz",
-      "integrity": "sha512-B90tYAUoLhU22olrafY3JQCFLnT3NglazdwkHyxNDYF/zAxJt5fJUB/yBoWFoIQ7SQj+KLe3iL4BhOMa9fzgpw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.21.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.21.2.tgz",
-      "integrity": "sha512-7twFizNXudESmC9oneLGIUmoHiiLppz/Xs5uJQ4ShvE6234K0VB1/aJYU3f/4g7PhssLGKBVCC37uRkkOi8wjg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.21.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.21.2.tgz",
-      "integrity": "sha512-9rRero0E7qTeYf6+rFh3AErTNU1VCQg2mn7CQcI44vNUWM9Ze7MSRS/9RFuSsox+vstRt97+x3sOhEey024FRQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.21.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.21.2.tgz",
-      "integrity": "sha512-5rA4vjlqgrpbFVVHX3qkrCo/fZTj1q0Xxpg+Z7yIo3J2AilW7t2+n6Q8Jrx+4MrYpAnjttTYF8rr7bP46BPzRw==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "packages/@apphosting/adapter-angular/node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.21.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.21.2.tgz",
-      "integrity": "sha512-6UUxd0+SKomjdzuAcp+HAmxw1FlGBnl1v2yEPSabtx4lBfdXHDVsW7+lQkgz9cNFJGY3AWR7+V8P5BqkD9L9nA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
     "packages/@apphosting/adapter-angular/node_modules/ansi-regex": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
@@ -26073,41 +25678,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "packages/@apphosting/adapter-angular/node_modules/rollup": {
-      "version": "4.21.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.21.2.tgz",
-      "integrity": "sha512-e3TapAgYf9xjdLvKQCkQTnbTKd4a6jwlpQSJJFokHGaX2IVjoEqkIIhiQfqsi0cdwlOD+tQGuOd5AJkc5RngBw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "1.0.5"
-      },
-      "bin": {
-        "rollup": "dist/bin/rollup"
-      },
-      "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=8.0.0"
-      },
-      "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.21.2",
-        "@rollup/rollup-android-arm64": "4.21.2",
-        "@rollup/rollup-darwin-arm64": "4.21.2",
-        "@rollup/rollup-darwin-x64": "4.21.2",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.21.2",
-        "@rollup/rollup-linux-arm-musleabihf": "4.21.2",
-        "@rollup/rollup-linux-arm64-gnu": "4.21.2",
-        "@rollup/rollup-linux-arm64-musl": "4.21.2",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.21.2",
-        "@rollup/rollup-linux-riscv64-gnu": "4.21.2",
-        "@rollup/rollup-linux-s390x-gnu": "4.21.2",
-        "@rollup/rollup-linux-x64-gnu": "4.21.2",
-        "@rollup/rollup-linux-x64-musl": "4.21.2",
-        "@rollup/rollup-win32-arm64-msvc": "4.21.2",
-        "@rollup/rollup-win32-ia32-msvc": "4.21.2",
-        "@rollup/rollup-win32-x64-msvc": "4.21.2",
-        "fsevents": "~2.3.2"
       }
     },
     "packages/@apphosting/adapter-angular/node_modules/strip-ansi": {
@@ -26125,6 +25695,7 @@
       }
     },
     "packages/@apphosting/adapter-angular/src/simple-server": {
+      "extraneous": true,
       "dependencies": {
         "@rollup/plugin-json": "^6.1.0",
         "express": "^4.18.2",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "workspaces": [
     "packages/@apphosting/*",
-    "packages/create-next-on-firebase/*",
+    "packages/create-next-on-firebase",
     "packages/firebase-frameworks"
   ],
   "devDependencies": {

--- a/packages/@apphosting/adapter-angular/package.json
+++ b/packages/@apphosting/adapter-angular/package.json
@@ -41,7 +41,7 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "@apphosting/common": "^0.0.2",
+    "@apphosting/common": "*",
     "firebase-functions": "^4.3.1",
     "fs-extra": "^11.1.1",
     "strip-ansi": "^7.1.0",

--- a/packages/@apphosting/adapter-nextjs/package.json
+++ b/packages/@apphosting/adapter-nextjs/package.json
@@ -41,7 +41,7 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "@apphosting/common": "^0.0.2",
+    "@apphosting/common": "*",
     "fs-extra": "^11.1.1",
     "yaml": "^2.3.4"
   },

--- a/packages/@apphosting/build/package.json
+++ b/packages/@apphosting/build/package.json
@@ -33,11 +33,11 @@
     ],
     "license": "Apache-2.0",
     "dependencies": {
+        "@apphosting/discover": "*",
         "colorette": "^2.0.20",
         "commander": "^11.1.0",
         "npm-pick-manifest": "^9.0.0",
-        "ts-node": "^10.9.1",
-        "@apphosting/discover": "*"
+        "ts-node": "^10.9.1"
     },
     "devDependencies": {
         "@types/commander": "*"

--- a/packages/@apphosting/discover/package.json
+++ b/packages/@apphosting/discover/package.json
@@ -39,8 +39,8 @@
         "commander": "^11.1.0",
         "fs-extra": "^11.1.1",
         "npm-pick-manifest": "^9.0.0",
-        "ts-node": "^10.9.1",
         "toml": "^3.0.0",
+        "ts-node": "^10.9.1",
         "yaml": "^2.3.4"
     },
     "devDependencies": {

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,8 +1,8 @@
 #! /usr/bin/env node
 const { spawn } = require("child_process");
-const { lernaScopeArgs } = require("./github.js");
+const { lernaScopes } = require("./github.js");
 
-const buildProcess = spawn("lerna", ["run", "build", ...lernaScopeArgs], { stdio: "inherit" });
+const buildProcess = spawn("lerna", ["run", "build", ...lernaScopes], { stdio: "inherit" });
 
 buildProcess.on("close", (code) => {
   process.exit(code);

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -2,7 +2,9 @@
 const { spawn } = require("child_process");
 const { lernaScopes } = require("./github.js");
 
-const buildProcess = spawn("lerna", ["run", "build", ...lernaScopes], { stdio: "inherit" });
+const buildProcess = spawn("lerna", ["run", "build", "--include-dependencies", ...lernaScopes], {
+  stdio: "inherit",
+});
 
 buildProcess.on("close", (code) => {
   process.exit(code);

--- a/scripts/github.js
+++ b/scripts/github.js
@@ -10,28 +10,26 @@ const since = process.env.GITHUB_ACTION
     }`
   : "";
 
-const lernaList = JSON.parse(
-  execSync("lerna list --json", { stdio: ["ignore", "pipe", "ignore"] }).toString(),
-);
+const lernaList = JSON.parse(execSync("lerna list --json --loglevel error"));
 
 const ref = process.env.GITHUB_SHA ?? "HEAD";
 const shortSHA = execSync(`git rev-parse --short ${ref}`).toString().trim();
 
 const scopedLernaList = JSON.parse(
   execSync(
-    `lerna list --json --no-private --toposort --include-dependents ${
+    `lerna list --json --no-private --toposort --loglevel error --include-dependents ${
       packagePatternFromRef ? `--scope='{,*/}${packagePatternFromRef}'` : since
     }`,
-    { stdio: ["ignore", "pipe", "ignore"] },
-  ).toString(),
+  ),
 );
 
-const packagesFromRef = packagePatternFromRef && JSON.parse(
-  execSync(
-    `lerna list --json --no-private --scope='{,*/}${packagePatternFromRef}'`,
-    { stdio: ["ignore", "pipe", "ignore"] },
-  ).toString(),
-);
+const packagesFromRef =
+  packagePatternFromRef &&
+  JSON.parse(
+    execSync(
+      `lerna list --json --no-private --loglevel error --scope='{,*/}${packagePatternFromRef}'`,
+    ),
+  );
 if (packagePatternFromRef && packagesFromRef.length !== 1) {
   throw new Error(`Lerna didn't find ${packageFromRef} in this workspace`);
 }
@@ -40,11 +38,11 @@ const packageFromRef = packagesFromRef?.[0].name;
 const lernaScopes = scopedLernaList.map(({ name }) => ["--scope", name]).flat();
 
 module.exports = {
-  taggedRelease: packageFromRef ? {
+  taggedRelease: packageFromRef && {
     name: packageFromRef,
     version: versionFromRef,
     tag: prereleaseFromRef ? "next" : "latest",
-  } : undefined,
+  },
   lernaList,
   scopedLernaList,
   shortSHA,

--- a/scripts/github.js
+++ b/scripts/github.js
@@ -10,14 +10,14 @@ const since = process.env.GITHUB_ACTION
     }`
   : "";
 
-const lernaList = JSON.parse(execSync("lerna list --json --loglevel error"));
+const lernaList = JSON.parse(execSync("lerna list --json --loglevel silent"));
 
 const ref = process.env.GITHUB_SHA ?? "HEAD";
 const shortSHA = execSync(`git rev-parse --short ${ref}`).toString().trim();
 
 const scopedLernaList = JSON.parse(
   execSync(
-    `lerna list --json --no-private --toposort --loglevel error --include-dependents ${
+    `lerna list --json --no-private --toposort --loglevel silent --include-dependents ${
       packagePatternFromRef ? `--scope='{,*/}${packagePatternFromRef}'` : since
     }`,
   ),
@@ -27,7 +27,7 @@ const packagesFromRef =
   packagePatternFromRef &&
   JSON.parse(
     execSync(
-      `lerna list --json --no-private --loglevel error --scope='{,*/}${packagePatternFromRef}'`,
+      `lerna list --json --no-private --loglevel silent --scope='{,*/}${packagePatternFromRef}'`,
     ),
   );
 if (packagePatternFromRef && packagesFromRef.length !== 1) {

--- a/scripts/github.js
+++ b/scripts/github.js
@@ -11,18 +11,20 @@ const since = process.env.GITHUB_ACTION
   : "";
 
 const lernaList = JSON.parse(
+  execSync("lerna list --json", { stdio: ["ignore", "pipe", "ignore"] }).toString(),
+);
+
+const ref = process.env.GITHUB_SHA ?? "HEAD";
+const shortSHA = execSync(`git rev-parse --short ${ref}`).toString().trim();
+
+const filteredLernaList = JSON.parse(
   execSync(
     `lerna list --json --include-dependencies --include-dependents ${
       packageFromRef ? `--scope='{,*/}${packageFromRef}'` : since
     }`,
     { stdio: ["ignore", "pipe", "ignore"] },
   ).toString(),
-);
-
-const ref = process.env.GITHUB_SHA ?? "HEAD";
-const shortSHA = execSync(`git rev-parse --short ${ref}`).toString().trim();
-
-const filteredLernaList = lernaList.filter((lerna) => {
+).filter((lerna) => {
   if (lerna.private) return false;
   return true;
 });
@@ -37,6 +39,7 @@ module.exports = {
   packageFromRef,
   versionFromRef,
   prerelease: !packageFromRef || !!prerelease,
+  lernaList,
   filteredLernaList,
   shortSHA,
   lernaScopeArgs,

--- a/scripts/github.js
+++ b/scripts/github.js
@@ -20,7 +20,7 @@ const shortSHA = execSync(`git rev-parse --short ${ref}`).toString().trim();
 const filteredLernaList = JSON.parse(
   execSync(
     `lerna list --json --toposort --include-dependents ${
-      packageFromRef ? `--scope='{,*/}${packageFromRef}'` : `${since} --include-dependencies`
+      packageFromRef ? `--scope='{,*/}${packageFromRef}'` : since
     }`,
     { stdio: ["ignore", "pipe", "ignore"] },
   ).toString(),

--- a/scripts/github.js
+++ b/scripts/github.js
@@ -31,7 +31,7 @@ const packagesFromRef =
     ),
   );
 if (packagePatternFromRef && packagesFromRef.length !== 1) {
-  throw new Error(`Lerna didn't find ${packageFromRef} in this workspace`);
+  throw new Error(`Tag pattern matched more than one package...`);
 }
 const packageFromRef = packagesFromRef?.[0].name;
 

--- a/scripts/github.js
+++ b/scripts/github.js
@@ -19,8 +19,8 @@ const shortSHA = execSync(`git rev-parse --short ${ref}`).toString().trim();
 
 const filteredLernaList = JSON.parse(
   execSync(
-    `lerna list --json --include-dependencies --include-dependents ${
-      packageFromRef ? `--scope='{,*/}${packageFromRef}'` : since
+    `lerna list --json --toposort --include-dependents ${
+      packageFromRef ? `--scope='{,*/}${packageFromRef}'` : `${since} --include-dependencies`
     }`,
     { stdio: ["ignore", "pipe", "ignore"] },
   ).toString(),

--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -53,7 +53,9 @@ for (const package of packagesToPublish) {
         const dependencyBeingPublished = packagesToPublish.find((it) => it.name === dependencyName);
         const dependencyVersion = dependencyBeingPublished?.version || lernaDependency.version;
         const dependencyPrerelease = dependencyVersion.includes("-");
-        package.dependencies[dependencyName] = dependencyPrerelease ? dependencyVersion : `^${dependencyVersion}`;
+        package.dependencies[dependencyName] = dependencyPrerelease
+          ? dependencyVersion
+          : `^${dependencyVersion}`;
       }
     }
   }

--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -2,7 +2,7 @@
 const { execSync } = require("child_process");
 const { writeFileSync, readFileSync } = require("fs");
 const { join } = require("path");
-const { filteredLernaList, versionFromRef, shortSHA, prerelease } = require("./github.js");
+const { filteredLernaList, lernaList, versionFromRef, shortSHA, prerelease } = require("./github.js");
 
 const wombatDressingRoomTokens = new Map([
   // ['firebase-frameworks', process.env.FIREBASE_FRAMEWORKS_NPM_TOKEN],
@@ -17,7 +17,7 @@ wombatDressingRoomTokens.forEach((token, pkg) => {
   });
 });
 
-for (const lerna of filteredLernaList) {
+const packagesToPublish = filteredLernaList.map((lerna) => {
   if (versionFromRef && versionFromRef.split("-")[0] !== lerna.version) {
     throw new Error(
       `Cowardly refusing to publish ${lerna.name}@${versionFromRef} from ${lerna.version}, version needs to be bumped in source.`,
@@ -29,16 +29,25 @@ for (const lerna of filteredLernaList) {
   const packageJsonPath = join(lerna.location, "package.json");
   const packageJson = JSON.parse(readFileSync(packageJsonPath).toString());
   packageJson.version = version;
-  for (const dependency of packageJson.dependencies) {
-    const lernaPackage = filteredLernaList.find(it => it.name === dependency[0]);
+  return packageJson;
+});
+
+for (packageJson of packagesToPublish) {
+  for (const dependency in packageJson.dependencies) {
+    const lernaPackage = lernaList.find(it => it.name === dependency);
     if (lernaPackage) {
-      dependency[1] = lernaPackage.version;
+      const changedPackage = packagesToPublish.find(it => it.name === dependency);
+      packageJson.dependencies[dependency] = changedPackage?.version || lernaPackage.version;
     }
   }
+  const lerna = lernaList.find(it => it.name === packageJson.name);
+  if (!lerna) { throw packageJson.name }
+  const packageJsonPath = join(lerna.location, "package.json");
   writeFileSync(packageJsonPath, JSON.stringify(packageJson, undefined, 2));
   const registry = wombatDressingRoomTokens.get(lerna.name)
     ? `https://wombat-dressing-room.appspot.com/${lerna.name}/_ns`
     : "https://registry.npmjs.org";
-  console.log(`npm publish --registry ${registry} --access public --tag ${tag} --provenance`, { cwd });
-    // execSync(`npm publish --registry ${registry} --access public --tag ${tag} --provenance`, { cwd });
+  const cwd = lerna.location;
+  const tag = versionFromRef ? (prerelease ? "next" : "latest") : "canary";
+  execSync(`npm publish --registry ${registry} --access public --tag ${tag} --provenance`, { cwd });
 }

--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -29,9 +29,16 @@ for (const lerna of filteredLernaList) {
   const packageJsonPath = join(lerna.location, "package.json");
   const packageJson = JSON.parse(readFileSync(packageJsonPath).toString());
   packageJson.version = version;
+  for (const dependency of packageJson.dependencies) {
+    const lernaPackage = filteredLernaList.find(it => it.name === dependency[0]);
+    if (lernaPackage) {
+      dependency[1] = lernaPackage.version;
+    }
+  }
   writeFileSync(packageJsonPath, JSON.stringify(packageJson, undefined, 2));
   const registry = wombatDressingRoomTokens.get(lerna.name)
     ? `https://wombat-dressing-room.appspot.com/${lerna.name}/_ns`
     : "https://registry.npmjs.org";
-  execSync(`npm publish --registry ${registry} --access public --tag ${tag} --provenance`, { cwd });
+  console.log(`npm publish --registry ${registry} --access public --tag ${tag} --provenance`, { cwd });
+    // execSync(`npm publish --registry ${registry} --access public --tag ${tag} --provenance`, { cwd });
 }

--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -30,7 +30,9 @@ const packagesToPublish = scopedLernaList.map((lerna) => {
       `Cowardly refusing to publish ${lerna.name}@${versionFromRef} from ${lerna.version}, version needs to be bumped in source.`,
     );
   }
-  const newVersion = isTaggedRelease ? taggedRelease.version : `${lerna.version}-canary.${shortSHA}`;
+  const newVersion = isTaggedRelease
+    ? taggedRelease.version
+    : `${lerna.version}-canary.${shortSHA}`;
   const registry = wombatDressingRoomTokens.get(lerna.name)
     ? `https://wombat-dressing-room.appspot.com/${lerna.name}/_ns`
     : "https://registry.npmjs.org";

--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -56,9 +56,8 @@ for (const package of packagesToPublish) {
       }
     }
   }
-  const lerna = lernaList.find((it) => it.name === package.name);
-  const packageJsonPath = join(lerna.location, "package.json");
+  const { location } = lernaList.find((it) => it.name === package.name);
+  const packageJsonPath = join(location, "package.json");
   writeFileSync(packageJsonPath, JSON.stringify(package, undefined, 2));
-  const cwd = lerna.location;
-  execSync(`npm publish`, { cwd });
+  execSync(`npm publish`, { cwd: location });
 }

--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -52,7 +52,8 @@ for (const package of packagesToPublish) {
       if (lernaDependency) {
         const dependencyBeingPublished = packagesToPublish.find((it) => it.name === dependencyName);
         const dependencyVersion = dependencyBeingPublished?.version || lernaDependency.version;
-        package.dependencies[dependencyName] = dependencyVersion;
+        const dependencyPrerelease = dependencyVersion.includes("-");
+        package.dependencies[dependencyName] = dependencyPrerelease ? dependencyVersion : `^${dependencyVersion}`;
       }
     }
   }

--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -44,25 +44,21 @@ const packagesToPublish = scopedLernaList.map((lerna) => {
   return packageJson;
 });
 
-for (const packageJson of packagesToPublish) {
-  for (const dependency in packageJson.dependencies) {
-    if (dependency) {
-      const lernaPackage = lernaList.find((it) => it.name === dependency);
-      if (lernaPackage) {
-        const changedPackage = packagesToPublish.find((it) => it.name === dependency);
-        const version = changedPackage?.version || lernaPackage.version;
-        if (packageJson.publishConfig.tag === "latest" && version.includes("-")) {
-          throw new Error(
-            `Cowardly refusing to publish ${packageJson.name}@${packageJson.version} with dependency on a pre-release ${dependency}@${version}`,
-          );
-        }
-        packageJson.dependencies[dependency] = version;
+for (const package of packagesToPublish) {
+  for (const dependencyName in package.dependencies) {
+    // for/in needs an if to make lint happy
+    if (dependencyName) {
+      const lernaDependency = lernaList.find((it) => it.name === dependencyName);
+      if (lernaDependency) {
+        const dependencyBeingPublished = packagesToPublish.find((it) => it.name === dependencyName);
+        const dependencyVersion = dependencyBeingPublished?.version || lernaDependency.version;
+        package.dependencies[dependencyName] = dependencyVersion;
       }
     }
   }
-  const lerna = lernaList.find((it) => it.name === packageJson.name);
+  const lerna = lernaList.find((it) => it.name === package.name);
   const packageJsonPath = join(lerna.location, "package.json");
-  writeFileSync(packageJsonPath, JSON.stringify(packageJson, undefined, 2));
+  writeFileSync(packageJsonPath, JSON.stringify(package, undefined, 2));
   const cwd = lerna.location;
   execSync(`npm publish`, { cwd });
 }

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -1,8 +1,8 @@
 #! /usr/bin/env node
 const { spawn } = require("child_process");
-const { lernaScopeArgs } = require("./github.js");
+const { lernaScopes } = require("./github.js");
 
-const testProcess = spawn("lerna", ["run", "test", "--verbose", "--no-bail", ...lernaScopeArgs], {
+const testProcess = spawn("lerna", ["run", "test", "--verbose", "--no-bail", ...lernaScopes], {
   stdio: "inherit",
 });
 testProcess.on("close", (code) => {


### PR DESCRIPTION
Seeing failures [since the changes to `@apphosting/common`](https://github.com/FirebaseExtended/firebase-framework-tools/actions/runs/10822830253/job/30027361965?pr=232). It turns out that in lerna, for the dependency graph to pick up dependents / dependencies the version in the package.json dependencies needs to be in the form of `*`

* Change monorepo dependencies to `*`, that's the easy part
* Now we don't want to allow any version of `@apphosting/common` as a dependency of `@apphosting/adapter-*`, so let's pin before we publish to the registry
  * Do two passes on the scopedLernaList (fka filteredLernaList)
    1. make a new package.json—set the new version and publishConfig
    1. pin dependencies to any versions from the first pass, write to disk, publish
  * Topo sort the lerna list, so packages are published in the correct order
* We should be building dependencies but only publishing dependents, move `--include-dependencies` into `build.js`
  * As build/test use the same scopedLernaList as publish, which has `--include-dependents`, changes to `@apphosting/common` will still trigger `@apphosting/adapter-*` tests to ensure we haven't introduced breaking changes
  * This went unnoticed before as dep tracking wasn't functioning
* Readability pass

Lerna publish would do much of this all for us, if we were using that... but I don't like the loss of control we'd suffer there, seems too magic.
