### PR TITLE
fix: Next.js boilerplate - link to ISR on-demand page

### DIFF
--- a/starters/nextjs/basic/src/app/isr/page.tsx
+++ b/starters/nextjs/basic/src/app/isr/page.tsx
@@ -15,7 +15,7 @@ export default function Page() {
         </article>
         <article className="card">
           <h2>
-            <Link href="/isr/time" className="link">
+            <Link href="/isr/demand" className="link">
               On-demand revalidation
             </Link>
           </h2>


### PR DESCRIPTION
Both links on the ISR page point to the time-based example. The other link should point to the on-demand example.

Side note: There is no link from the site root page to the ISR page, which should probably be also addressed in another pull request by someone with more insight into the project.