### PR TITLE
feat: support `@angular/build:application` builder

### DIFF
--- a/packages/@apphosting/adapter-angular/src/utils.ts
+++ b/packages/@apphosting/adapter-angular/src/utils.ts
@@ -26,6 +26,7 @@ const SIMPLE_SERVER_FILE_PATH = join(__dirname, "simple-server", "bundled_server
 
 export const ALLOWED_BUILDERS = [
   "@angular-devkit/build-angular:application",
+  "@angular/build:application",
   "@analogjs/platform:vite",
 ];
 


### PR DESCRIPTION
This adds support for the `@angular/build:application` builder.

The ESBuild-based build system has been migrated to the `@angular/build` package. `@angular-devkit/build-angular:application` simply redirects to `@angular/build`.