### PR TITLE
Fix typo in example bundle.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,11 +108,9 @@ interface Metadata {
 | `framework` | `string` | Name of the framework that is being supported | y |
 | `frameworkVersion` | `string` |Version of the framework that is being supported | n |
 
-Here is a sample `bundle.yaml` file putting all this together:
+Here is a sample `.apphosting/bundle.yaml` file putting all this together:
 
-```
-> cat .apphosting/bundle.yaml
-
+```yaml
 version: v1
 runConfig:
   runCommand: 'node dist/index.js'
@@ -131,7 +129,6 @@ metadata:
   adapterVersion: 12.0.0
   framework: framework-name
   frameworkVersion: 1.0.0
-
 ```
 
 As long as you have the `bundle.yaml` in this format, App Hosting will be able to deploy any framework that supports server side rendering.

--- a/README.md
+++ b/README.md
@@ -115,9 +115,7 @@ Here is a sample `bundle.yaml` file putting all this together:
 
 version: v1
 runConfig:
-  runCommand:
-    - node
-    - dist/index.js
+  runCommand: 'node dist/index.js'
   environmentVariables:
     - variable: VAR
       value: 8080

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ metadata:
   adapterNpmPackageName: npm-name
   adapterVersion: 12.0.0
   frameworkNpmPackageName: framework-name
-  adapterVersion: 1.0.0
+  frameworkVersion: 1.0.0
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -129,9 +129,9 @@ runConfig:
   maxInstances: 14
     
 metadata:
-  adapterNpmPackageName: npm-name
+  adapterPackageName: npm-name
   adapterVersion: 12.0.0
-  frameworkNpmPackageName: framework-name
+  framework: framework-name
   frameworkVersion: 1.0.0
 
 ```


### PR DESCRIPTION
- Remove second `adapterVersion` and replace it with `frameworkVersion`.
- Remove `Npm` from metadata field name
- Make `runCommand` a string instead of a list