### PR TITLE
Allow firebase-admin 13.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26113,7 +26113,7 @@
       },
       "peerDependencies": {
         "firebase": "^9.9.0 || ^10.0.0 || ^11.0.0",
-        "firebase-admin": "^11.0.1 || ^12.0.0",
+        "firebase-admin": "^11.0.1 || ^12.0.0 || ^13.0.0",
         "sharp": "^0.32 || ^0.33"
       },
       "peerDependenciesMeta": {

--- a/packages/firebase-frameworks/package.json
+++ b/packages/firebase-frameworks/package.json
@@ -54,7 +54,7 @@
   },
   "peerDependencies": {
     "firebase": "^9.9.0 || ^10.0.0 || ^11.0.0",
-    "firebase-admin": "^11.0.1 || ^12.0.0",
+    "firebase-admin": "^11.0.1 || ^12.0.0 || ^13.0.0",
     "sharp": "^0.32 || ^0.33"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
Update peerDependencies so downstream dependencies have the option of using firebase-admin 13.x

Duplication/Resolves https://github.com/FirebaseExtended/firebase-framework-tools/pull/288