### PR TITLE
Bug/fix nextjs adapter functional tests

### DIFF
--- a/packages/@apphosting/adapter-nextjs/e2e/app.spec.ts
+++ b/packages/@apphosting/adapter-nextjs/e2e/app.spec.ts
@@ -12,14 +12,14 @@ describe("app", () => {
     const response = await fetch(host);
     assert.ok(response.ok);
     assert.equal(response.headers.get("content-type")?.toLowerCase(), "text/html; charset=utf-8");
-    assert.equal(response.headers.get("cache-control"), "s-maxage=31536000");
+    assert.equal(response.headers.get("cache-control"), "s-maxage=31536000, ");
   });
 
   it("/ssg", async () => {
     const response = await fetch(posix.join(host, "ssg"));
     assert.ok(response.ok);
     assert.equal(response.headers.get("content-type")?.toLowerCase(), "text/html; charset=utf-8");
-    assert.equal(response.headers.get("cache-control"), "s-maxage=31536000");
+    assert.equal(response.headers.get("cache-control"), "s-maxage=31536000, ");
     const text = await response.text();
     assert.ok(text.includes("SSG"));
     assert.ok(text.includes("Generated"));
@@ -74,7 +74,7 @@ describe("app", () => {
     const response = await fetch(posix.join(host, "isr", "demand"));
     assert.ok(response.ok);
     assert.equal(response.headers.get("content-type")?.toLowerCase(), "text/html; charset=utf-8");
-    assert.equal(response.headers.get("cache-control"), "s-maxage=31536000");
+    assert.equal(response.headers.get("cache-control"), "s-maxage=31536000, ");
     const text = await response.text();
     assert.ok(text.includes("A cached page"));
     assert.ok(text.includes("Generated"));

--- a/packages/@apphosting/adapter-nextjs/e2e/app.spec.ts
+++ b/packages/@apphosting/adapter-nextjs/e2e/app.spec.ts
@@ -12,20 +12,14 @@ describe("app", () => {
     const response = await fetch(host);
     assert.ok(response.ok);
     assert.equal(response.headers.get("content-type")?.toLowerCase(), "text/html; charset=utf-8");
-    assert.equal(
-      response.headers.get("cache-control"),
-      "s-maxage=31536000, stale-while-revalidate",
-    );
+    assert.equal(response.headers.get("cache-control"), "s-maxage=31536000");
   });
 
   it("/ssg", async () => {
     const response = await fetch(posix.join(host, "ssg"));
     assert.ok(response.ok);
     assert.equal(response.headers.get("content-type")?.toLowerCase(), "text/html; charset=utf-8");
-    assert.equal(
-      response.headers.get("cache-control"),
-      "s-maxage=31536000, stale-while-revalidate",
-    );
+    assert.equal(response.headers.get("cache-control"), "s-maxage=31536000");
     const text = await response.text();
     assert.ok(text.includes("SSG"));
     assert.ok(text.includes("Generated"));
@@ -80,10 +74,7 @@ describe("app", () => {
     const response = await fetch(posix.join(host, "isr", "demand"));
     assert.ok(response.ok);
     assert.equal(response.headers.get("content-type")?.toLowerCase(), "text/html; charset=utf-8");
-    assert.equal(
-      response.headers.get("cache-control"),
-      "s-maxage=31536000, stale-while-revalidate",
-    );
+    assert.equal(response.headers.get("cache-control"), "s-maxage=31536000");
     const text = await response.text();
     assert.ok(text.includes("A cached page"));
     assert.ok(text.includes("Generated"));

--- a/packages/@apphosting/adapter-nextjs/e2e/run-local.ts
+++ b/packages/@apphosting/adapter-nextjs/e2e/run-local.ts
@@ -70,6 +70,7 @@ const run = spawn(runScript, runArgs, {
   env: {
     NODE_ENV: "production",
     PORT: port.toString(),
+    PATH: process.env.PATH,
   },
 });
 run.stderr.on("data", (data) => console.error(data.toString()));

--- a/starters/nextjs/basic/.eslintrc.json
+++ b/starters/nextjs/basic/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-  "extends": "next/core-web-vitals"
-}

--- a/starters/nextjs/basic/eslint.config.mjs
+++ b/starters/nextjs/basic/eslint.config.mjs
@@ -1,0 +1,11 @@
+import { FlatCompat } from "@eslint/eslintrc";
+const compat = new FlatCompat({
+  // import.meta.dirname is available after Node.js v20.11.0
+  baseDirectory: import.meta.dirname,
+});
+const eslintConfig = [
+  ...compat.config({
+    extends: ["next/core-web-vitals"],
+  }),
+];
+export default eslintConfig;


### PR DESCRIPTION
Was getting eslint errors and failing E2E errors when running `npm run test` from the NextJS adapter. This PR:
1. updates the basic nextjs project to use eslint.config.mjs instead of .eslintrc.json, which seems to be the [preferred way for Next 15](https://nextjs.org/docs/app/api-reference/config/eslint#with-core-web-vitals)
2. Fixes breaking e2e tests for the NextJS adapter as they're breaking (could be the Next 15 upgrade: https://github.com/FirebaseExtended/firebase-framework-tools/pull/247) 