### PR TITLE
NextJS Adapter Bug Fix - Invalid next import

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25618,7 +25618,7 @@
       }
     },
     "packages/@apphosting/adapter-nextjs": {
-      "version": "14.0.10",
+      "version": "14.0.11",
       "license": "Apache-2.0",
       "dependencies": {
         "@apphosting/common": "*",

--- a/packages/@apphosting/adapter-nextjs/package.json
+++ b/packages/@apphosting/adapter-nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apphosting/adapter-nextjs",
-  "version": "14.0.10",
+  "version": "14.0.11",
   "main": "dist/index.js",
   "description": "Experimental addon to the Firebase CLI to add web framework support",
   "repository": {

--- a/packages/@apphosting/adapter-nextjs/src/utils.ts
+++ b/packages/@apphosting/adapter-nextjs/src/utils.ts
@@ -4,12 +4,15 @@ import { join, dirname, relative, normalize } from "path";
 import { fileURLToPath } from "url";
 import { stringify as yamlStringify } from "yaml";
 
-import { PHASE_PRODUCTION_BUILD, ROUTES_MANIFEST } from "./constants.js";
-import { OutputBundleOptions, RoutesManifest } from "./interfaces.js";
+import { PHASE_PRODUCTION_BUILD, ROUTES_MANIFEST, MIDDLEWARE_MANIFEST } from "./constants.js";
+import {
+  OutputBundleOptions,
+  RoutesManifest,
+  AdapterMetadata,
+  MiddlewareManifest,
+} from "./interfaces.js";
 import { NextConfigComplete } from "next/dist/server/config-shared.js";
 import { OutputBundleConfig } from "@apphosting/common";
-import { AdapterMetadata, MiddlewareManifest } from "./interfaces.js";
-import { MIDDLEWARE_MANIFEST } from "next/constants.js";
 
 // fs-extra is CJS, readJson can't be imported using shorthand
 export const { move, exists, writeFile, readJson, readdir, readFileSync, existsSync, mkdir } =


### PR DESCRIPTION
Seeing the following error when building a nextjs app in staging:
![Screenshot 2025-03-04 at 3 29 05 PM](https://github.com/user-attachments/assets/94b8217b-a4d5-4dfa-8008-710d5bf046ba)

The error was introduced in the 14.0.10 release of the NextJs adapter, with the header override changes. 