### PR TITLE
Make Angular manifest parsing more robust

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25520,7 +25520,7 @@
       }
     },
     "packages/@apphosting/adapter-angular": {
-      "version": "17.2.12",
+      "version": "17.2.13",
       "license": "Apache-2.0",
       "dependencies": {
         "@apphosting/common": "*",

--- a/packages/@apphosting/adapter-angular/package.json
+++ b/packages/@apphosting/adapter-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apphosting/adapter-angular",
-  "version": "17.2.12",
+  "version": "17.2.13",
   "main": "dist/index.js",
   "description": "Experimental addon to the Firebase CLI to add web framework support",
   "repository": {

--- a/packages/@apphosting/adapter-angular/src/utils.ts
+++ b/packages/@apphosting/adapter-angular/src/utils.ts
@@ -108,7 +108,7 @@ export function populateOutputBundleOptions(outputPaths: OutputPaths): OutputBun
 
 export function parseOutputBundleOptions(buildOutput: string): OutputBundleOptions {
   const strippedManifest = extractManifestOutput(buildOutput);
-  const parsedManifest = JSON.parse(strippedManifest.replace(/[\r\n]+/g, '')) as string;
+  const parsedManifest = JSON.parse(strippedManifest.replace(/[\r\n]+/g, "")) as string;
   const manifest = buildManifestSchema.parse(parsedManifest);
   if (manifest["errors"].length > 0) {
     // errors when extracting manifest

--- a/packages/@apphosting/adapter-angular/src/utils.ts
+++ b/packages/@apphosting/adapter-angular/src/utils.ts
@@ -108,7 +108,7 @@ export function populateOutputBundleOptions(outputPaths: OutputPaths): OutputBun
 
 export function parseOutputBundleOptions(buildOutput: string): OutputBundleOptions {
   const strippedManifest = extractManifestOutput(buildOutput);
-  const parsedManifest = JSON.parse(strippedManifest) as string;
+  const parsedManifest = JSON.parse(strippedManifest.replace(/[\r\n]+/g, '')) as string;
   const manifest = buildManifestSchema.parse(parsedManifest);
   if (manifest["errors"].length > 0) {
     // errors when extracting manifest

--- a/packages/@apphosting/adapter-angular/src/utils.ts
+++ b/packages/@apphosting/adapter-angular/src/utils.ts
@@ -108,6 +108,7 @@ export function populateOutputBundleOptions(outputPaths: OutputPaths): OutputBun
 
 export function parseOutputBundleOptions(buildOutput: string): OutputBundleOptions {
   const strippedManifest = extractManifestOutput(buildOutput);
+  // TODO: add functional tests that test this flow
   const parsedManifest = JSON.parse(strippedManifest.replace(/[\r\n]+/g, "")) as string;
   const manifest = buildManifestSchema.parse(parsedManifest);
   if (manifest["errors"].length > 0) {


### PR DESCRIPTION
This should fix the bug where people were occasionally the manifest file would add new line characters, breaking the parsing https://github.com/FirebaseExtended/firebase-framework-tools/issues/307