### PR TITLE
Loosen version check requirements

### DIFF
--- a/packages/@apphosting/adapter-angular/package.json
+++ b/packages/@apphosting/adapter-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apphosting/adapter-angular",
-  "version": "17.2.14",
+  "version": "17.2.15",
   "main": "dist/index.js",
   "description": "Experimental addon to the Firebase CLI to add web framework support",
   "repository": {

--- a/packages/@apphosting/adapter-angular/src/bin/build.ts
+++ b/packages/@apphosting/adapter-angular/src/bin/build.ts
@@ -12,9 +12,7 @@ const opts = getBuildOptions();
 
 // Check build conditions, which vary depending on your project structure (standalone or monorepo)
 await checkBuildConditions(opts);
-if (!process.env.FRAMEWORK_VERSION) {
-  throw new Error("Could not find the angular version of the application");
-}
+
 
 // enable JSON build logs for application builder
 process.env.NG_BUILD_LOGS_JSON = "1";
@@ -22,10 +20,12 @@ const { stdout: output } = await runBuild();
 if (!output) {
   throw new Error("No output from Angular build command, expecting a build manifest file.");
 }
+
+const angularVersion = process.env.FRAMEWORK_VERSION || "undefined";
 if (!outputBundleExists()) {
   const outputBundleOptions = parseOutputBundleOptions(output);
   const root = process.cwd();
-  await generateBuildOutput(root, outputBundleOptions, process.env.FRAMEWORK_VERSION);
+  await generateBuildOutput(root, outputBundleOptions, angularVersion);
 
   await validateOutputDirectory(outputBundleOptions);
 }

--- a/packages/@apphosting/adapter-nextjs/package.json
+++ b/packages/@apphosting/adapter-nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apphosting/adapter-nextjs",
-  "version": "14.0.13",
+  "version": "14.0.14",
   "main": "dist/index.js",
   "description": "Experimental addon to the Firebase CLI to add web framework support",
   "repository": {

--- a/packages/@apphosting/adapter-nextjs/src/bin/build.ts
+++ b/packages/@apphosting/adapter-nextjs/src/bin/build.ts
@@ -18,9 +18,6 @@ const opts = getBuildOptions();
 process.env.NEXT_PRIVATE_STANDALONE = "true";
 // Opt-out sending telemetry to Vercel
 process.env.NEXT_TELEMETRY_DISABLED = "1";
-if (!process.env.FRAMEWORK_VERSION) {
-  throw new Error("Could not find the nextjs version of the application");
-}
 
 const originalConfig = await loadConfig(root, opts.projectDirectory);
 
@@ -57,12 +54,13 @@ await addRouteOverrides(
   adapterMetadata,
 );
 
+const nextjsVersion = process.env.FRAMEWORK_VERSION || 'undefined'
 await generateBuildOutput(
   root,
   opts.projectDirectory,
   outputBundleOptions,
   nextBuildDirectory,
-  process.env.FRAMEWORK_VERSION,
+  nextjsVersion,
   adapterMetadata,
 );
 await validateOutputDirectory(outputBundleOptions, nextBuildDirectory);


### PR DESCRIPTION
We currently fail on a failure to pass in the version, we would probably rather not error out and continue the build to make the system less prone to failure as version is not required to build things