### PR TITLE
Filter out node_modules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25618,7 +25618,7 @@
       }
     },
     "packages/@apphosting/adapter-nextjs": {
-      "version": "14.0.14",
+      "version": "14.0.15",
       "license": "Apache-2.0",
       "dependencies": {
         "@apphosting/common": "*",

--- a/packages/@apphosting/adapter-nextjs/package.json
+++ b/packages/@apphosting/adapter-nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apphosting/adapter-nextjs",
-  "version": "14.0.14",
+  "version": "14.0.15",
   "main": "dist/index.js",
   "description": "Experimental addon to the Firebase CLI to add web framework support",
   "repository": {

--- a/packages/@apphosting/adapter-nextjs/src/bin/build.spec.ts
+++ b/packages/@apphosting/adapter-nextjs/src/bin/build.spec.ts
@@ -62,6 +62,10 @@ metadata:
   adapterVersion: ${adapterMetadata.adapterVersion}
   framework: nextjs
   frameworkVersion: ${defaultNextVersion}
+outputFiles:
+  serverApp:
+    include:
+      - .next/standalone
 `,
     };
     validateTestFiles(tmpDir, expectedFiles);

--- a/packages/@apphosting/adapter-nextjs/src/utils.ts
+++ b/packages/@apphosting/adapter-nextjs/src/utils.ts
@@ -194,9 +194,9 @@ async function generateBundleYaml(
     },
     outputFiles: {
       serverApp: {
-        include: [".next/standalone"]
-      }
-    }
+        include: [".next/standalone"],
+      },
+    },
   };
   await writeFile(opts.bundleYamlPath, yamlStringify(outputBundle));
   return;

--- a/packages/@apphosting/adapter-nextjs/src/utils.ts
+++ b/packages/@apphosting/adapter-nextjs/src/utils.ts
@@ -194,7 +194,7 @@ async function generateBundleYaml(
     },
     outputFiles: {
       serverApp: {
-        include: [".next/standalone"],
+        include: [".next/standalone"], // we're only including the standalone directory to exclude the node_modules folder specifically
       },
     },
   };

--- a/packages/@apphosting/adapter-nextjs/src/utils.ts
+++ b/packages/@apphosting/adapter-nextjs/src/utils.ts
@@ -151,7 +151,9 @@ async function moveResources(
   for (const path of pathsToMove) {
     const isbundleYamlDir = join(appDir, path) === dirname(bundleYamlPath);
     const existsInOutputBundle = await exists(join(outputBundleAppDir, path));
-    if (!isbundleYamlDir && !existsInOutputBundle) {
+    // Keep apphosting.yaml files in the root directory still, as later steps expect them to be there
+    const isApphostingYaml = path === "apphosting_preprocessed" || path === "apphosting.yaml";
+    if (!isbundleYamlDir && !existsInOutputBundle && !isApphostingYaml) {
       await move(join(appDir, path), join(outputBundleAppDir, path));
     }
   }
@@ -190,6 +192,11 @@ async function generateBundleYaml(
       framework: "nextjs",
       frameworkVersion: nextVersion,
     },
+    outputFiles: {
+      serverApp: {
+        include: [".next/standalone"]
+      }
+    }
   };
   await writeFile(opts.bundleYamlPath, yamlStringify(outputBundle));
   return;


### PR DESCRIPTION
Filters out all directories other than .next/standalone, in practice this will pretty much only delete the extra node_modules in the root directory, improving build speeds