### PR TITLE
Revert "Filter out node_modules"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25618,7 +25618,7 @@
       }
     },
     "packages/@apphosting/adapter-nextjs": {
-      "version": "14.0.15",
+      "version": "14.0.14",
       "license": "Apache-2.0",
       "dependencies": {
         "@apphosting/common": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25618,7 +25618,7 @@
       }
     },
     "packages/@apphosting/adapter-nextjs": {
-      "version": "14.0.14",
+      "version": "14.0.16",
       "license": "Apache-2.0",
       "dependencies": {
         "@apphosting/common": "*",

--- a/packages/@apphosting/adapter-nextjs/package.json
+++ b/packages/@apphosting/adapter-nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apphosting/adapter-nextjs",
-  "version": "14.0.14",
+  "version": "14.0.16",
   "main": "dist/index.js",
   "description": "Experimental addon to the Firebase CLI to add web framework support",
   "repository": {

--- a/packages/@apphosting/adapter-nextjs/package.json
+++ b/packages/@apphosting/adapter-nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apphosting/adapter-nextjs",
-  "version": "14.0.15",
+  "version": "14.0.14",
   "main": "dist/index.js",
   "description": "Experimental addon to the Firebase CLI to add web framework support",
   "repository": {

--- a/packages/@apphosting/adapter-nextjs/src/bin/build.spec.ts
+++ b/packages/@apphosting/adapter-nextjs/src/bin/build.spec.ts
@@ -62,10 +62,6 @@ metadata:
   adapterVersion: ${adapterMetadata.adapterVersion}
   framework: nextjs
   frameworkVersion: ${defaultNextVersion}
-outputFiles:
-  serverApp:
-    include:
-      - .next/standalone
 `,
     };
     validateTestFiles(tmpDir, expectedFiles);

--- a/packages/@apphosting/adapter-nextjs/src/utils.ts
+++ b/packages/@apphosting/adapter-nextjs/src/utils.ts
@@ -151,9 +151,7 @@ async function moveResources(
   for (const path of pathsToMove) {
     const isbundleYamlDir = join(appDir, path) === dirname(bundleYamlPath);
     const existsInOutputBundle = await exists(join(outputBundleAppDir, path));
-    // Keep apphosting.yaml files in the root directory still, as later steps expect them to be there
-    const isApphostingYaml = path === "apphosting_preprocessed" || path === "apphosting.yaml";
-    if (!isbundleYamlDir && !existsInOutputBundle && !isApphostingYaml) {
+    if (!isbundleYamlDir && !existsInOutputBundle) {
       await move(join(appDir, path), join(outputBundleAppDir, path));
     }
   }
@@ -191,11 +189,6 @@ async function generateBundleYaml(
       ...adapterMetadata,
       framework: "nextjs",
       frameworkVersion: nextVersion,
-    },
-    outputFiles: {
-      serverApp: {
-        include: [".next/standalone"], // we're only including the standalone directory to exclude the node_modules folder specifically
-      },
     },
   };
   await writeFile(opts.bundleYamlPath, yamlStringify(outputBundle));


### PR DESCRIPTION
Reverts FirebaseExtended/firebase-framework-tools#346

Temporarily reverts this change as it breaks NextJS Monorepo setups. See https://github.com/FirebaseExtended/firebase-framework-tools/issues/349.