### PR TITLE
Filter out node_modules without breaking nx monorepos

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25618,7 +25618,7 @@
       }
     },
     "packages/@apphosting/adapter-nextjs": {
-      "version": "14.0.16",
+      "version": "14.0.17",
       "license": "Apache-2.0",
       "dependencies": {
         "@apphosting/common": "*",

--- a/packages/@apphosting/adapter-nextjs/package.json
+++ b/packages/@apphosting/adapter-nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apphosting/adapter-nextjs",
-  "version": "14.0.16",
+  "version": "14.0.17",
   "main": "dist/index.js",
   "description": "Experimental addon to the Firebase CLI to add web framework support",
   "repository": {

--- a/packages/@apphosting/adapter-nextjs/src/bin/build.spec.ts
+++ b/packages/@apphosting/adapter-nextjs/src/bin/build.spec.ts
@@ -62,6 +62,10 @@ metadata:
   adapterVersion: ${adapterMetadata.adapterVersion}
   framework: nextjs
   frameworkVersion: ${defaultNextVersion}
+outputFiles:
+  serverApp:
+    include:
+      - .next/standalone
 `,
     };
     validateTestFiles(tmpDir, expectedFiles);

--- a/packages/@apphosting/adapter-nextjs/src/utils.ts
+++ b/packages/@apphosting/adapter-nextjs/src/utils.ts
@@ -151,7 +151,9 @@ async function moveResources(
   for (const path of pathsToMove) {
     const isbundleYamlDir = join(appDir, path) === dirname(bundleYamlPath);
     const existsInOutputBundle = await exists(join(outputBundleAppDir, path));
-    if (!isbundleYamlDir && !existsInOutputBundle) {
+    // Keep apphosting.yaml files in the root directory still, as later steps expect them to be there
+    const isApphostingYaml = path === "apphosting_preprocessed" || path === "apphosting.yaml";
+    if (!isbundleYamlDir && !existsInOutputBundle && !isApphostingYaml) {
       await move(join(appDir, path), join(outputBundleAppDir, path));
     }
   }
@@ -191,6 +193,14 @@ async function generateBundleYaml(
       frameworkVersion: nextVersion,
     },
   };
+  if (!process.env.MONOREPO_COMMAND) {
+    outputBundle.outputFiles = {
+      serverApp: {
+        include: [opts.outputDirectoryAppPath],
+      },
+    };
+  }
+
   await writeFile(opts.bundleYamlPath, yamlStringify(outputBundle));
   return;
 }


### PR DESCRIPTION
Round 2 of filtering out node_modules, this time with a carve out to avoid breaking monorepos