### PR TITLE
Fix monorepo build args split

### DIFF
--- a/packages/@apphosting/common/src/index.ts
+++ b/packages/@apphosting/common/src/index.ts
@@ -128,7 +128,7 @@ export function getBuildOptions(): BuildOptions {
   if (process.env.MONOREPO_COMMAND) {
     return {
       buildCommand: process.env.MONOREPO_COMMAND,
-      buildArgs: ["run", "build"].concat(process.env.MONOREPO_BUILD_ARGS?.split(".") || []),
+      buildArgs: ["run", "build"].concat(process.env.MONOREPO_BUILD_ARGS?.split(",") || []),
       projectDirectory: process.env.GOOGLE_BUILDABLE || "",
       projectName: process.env.MONOREPO_PROJECT,
     };


### PR DESCRIPTION
Currently in the buildpack our build args are joined together using "," instead of ".",  so MONOREPO_BUILD_ARGS should split by commas.