### PR TITLE
Refine and clean the Turbo + Angular JSON manifest output

### DIFF
--- a/packages/@apphosting/adapter-angular/package.json
+++ b/packages/@apphosting/adapter-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apphosting/adapter-angular",
-  "version": "17.2.15",
+  "version": "17.2.16",
   "main": "dist/index.js",
   "description": "Experimental addon to the Firebase CLI to add web framework support",
   "repository": {

--- a/packages/@apphosting/adapter-angular/src/utils.ts
+++ b/packages/@apphosting/adapter-angular/src/utils.ts
@@ -177,7 +177,7 @@ function extractManifestOutput(output: string): string {
   }
   // Clean the raw json string by removing the "web:build:" prefixes for a Turbo build
   const prefixRegex = /\n?web:build:/g;
-  const cleanedOutput = output.substring(start, end + 1).replace(prefixRegex, '');
+  const cleanedOutput = output.substring(start, end + 1).replace(prefixRegex, "");
   return stripAnsi(cleanedOutput);
 }
 

--- a/packages/@apphosting/adapter-angular/src/utils.ts
+++ b/packages/@apphosting/adapter-angular/src/utils.ts
@@ -175,7 +175,10 @@ function extractManifestOutput(output: string): string {
   if (start === -1 || end === -1 || start > end) {
     throw new Error(`Failed to find valid JSON object from build output: ${output}`);
   }
-  return stripAnsi(output.substring(start, end + 1));
+  // Clean the raw json string by removing the "web:build:" prefixes for a Turbo build
+  const prefixRegex = /\n?web:build:/g;
+  const cleanedOutput = output.substring(start, end + 1).replace(prefixRegex, '');
+  return stripAnsi(cleanedOutput);
 }
 
 /**

--- a/packages/@apphosting/common/package.json
+++ b/packages/@apphosting/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apphosting/common",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Shared library code for App Hosting framework adapters",
   "author": {
     "name": "Firebase",


### PR DESCRIPTION
This addresses an issue where Turbo builds, when used with Angular, introduce extraneous "web:build:" prefixes into the raw JSON manifest output. This PR strips these undesired prefixes, ensuring the Angular manifest get extracted in a proper format.  

This PR also bumps the angular adapter and the common folder versions. With the angular manifest parsing fix and the monorepo args split fix, the angular + turbo will be fixed. 