### PR TITLE
Add apphosting config interface to common.

### DIFF
--- a/packages/@apphosting/adapter-angular/src/interface.ts
+++ b/packages/@apphosting/adapter-angular/src/interface.ts
@@ -9,27 +9,6 @@ export interface OutputBundleOptions {
   needsServerGenerated: boolean;
 }
 
-// Environment variable schema for bundle.yaml outputted by angular adapter
-export interface EnvironmentVariable {
-  variable: string;
-  value: string;
-  availability: Availability.Runtime; // currently support RUNTIME only
-}
-
-// defines whether the environment variable is buildtime, runtime or both
-export enum Availability {
-  Buildtime = "BUILD",
-  Runtime = "RUNTIME",
-}
-
-// Metadata schema for bundle.yaml outputted by angular adapter
-export interface Metadata {
-  adapterPackageName: string;
-  adapterVersion: string;
-  framework: string;
-  frameworkVersion: string;
-}
-
 // valid manifest schema
 export interface ValidManifest {
   errors: string[];

--- a/packages/@apphosting/common/src/index.ts
+++ b/packages/@apphosting/common/src/index.ts
@@ -2,6 +2,8 @@ import { spawn } from "child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
 
+// **** OutputBundleConfig interfaces ****
+
 // Output bundle metadata specifications to be written to bundle.yaml
 export interface OutputBundleConfig {
   version: "v1";
@@ -41,6 +43,28 @@ export interface Metadata {
   frameworkVersion?: string;
 }
 
+// **** Apphosting Config interfaces ****
+
+export interface ApphostingConfig {
+  runconfig?: ApphostingRunConfig;
+  env?: EnvVarConfig[];
+  scripts?: Script;
+  outputFiles?: OutputFiles;
+}
+
+export interface ApphostingRunConfig{
+  minInstances?: number;
+  maxInstances?: number;
+  concurrency?: number;
+}
+
+export interface Script {
+  buildCommand?: string;
+  runCommand?: string;
+}
+
+// **** Shared interfaces ****
+
 // Optional outputFiles to configure outputFiles and optimize server files + static assets.
 // If this is not set then all of the source code will be uploaded
 interface OutputFiles {
@@ -59,7 +83,7 @@ export interface EnvVarConfig {
   variable: string;
   // Value associated with the variable
   value: string;
-  // Where the variable will be available, for now only RUNTIME is supported
+  // Where the variable will be available
   availability: Availability.Runtime[];
 }
 
@@ -67,7 +91,9 @@ export interface EnvVarConfig {
 export enum Availability {
   // Runtime environment variables are available on the server when the app is run
   Runtime = "RUNTIME",
+  Build = "BUILD",
 }
+
 
 // Options to configure the build of a framework application
 export interface BuildOptions {

--- a/packages/@apphosting/common/src/index.ts
+++ b/packages/@apphosting/common/src/index.ts
@@ -52,7 +52,7 @@ export interface ApphostingConfig {
   outputFiles?: OutputFiles;
 }
 
-export interface ApphostingRunConfig{
+export interface ApphostingRunConfig {
   minInstances?: number;
   maxInstances?: number;
   concurrency?: number;
@@ -93,7 +93,6 @@ export enum Availability {
   Runtime = "RUNTIME",
   Build = "BUILD",
 }
-
 
 // Options to configure the build of a framework application
 export interface BuildOptions {

--- a/packages/@apphosting/common/src/index.ts
+++ b/packages/@apphosting/common/src/index.ts
@@ -67,7 +67,7 @@ export interface Script {
 
 // Optional outputFiles to configure outputFiles and optimize server files + static assets.
 // If this is not set then all of the source code will be uploaded
-interface OutputFiles {
+export interface OutputFiles {
   serverApp: ServerApp;
 }
 
@@ -84,7 +84,7 @@ export interface EnvVarConfig {
   // Value associated with the variable
   value: string;
   // Where the variable will be available
-  availability: Availability.Runtime[];
+  availability: Availability[];
 }
 
 // Represents where environment variables are made available


### PR DESCRIPTION
- Add interfaces for the apphosting config, while sharing what can be shared with the bundle config
- remove unused and duplicate interfaces in adapter-angular
- Add 'Build' enum value for envvars availability. This was previously limited to "Runtime" because it was used only for bundle.yaml's envvars which are envvars set by the adapter after a build to be used for runtime. Now the envvars interface will be shared with the apphosting config