### PR TITLE
fix: Handle Next.js external URL rewrites to prevent 504 Gateway Timeout

### DIFF
--- a/packages/firebase-frameworks/src/next.js/index.ts
+++ b/packages/firebase-frameworks/src/next.js/index.ts
@@ -1,4 +1,6 @@
 import { parse } from "url";
+import { join } from "node:path";
+import { readFile } from "node:fs/promises";
 import createNextServer from "next";
 
 import type { Request } from "firebase-functions/v2/https";
@@ -15,7 +17,172 @@ const nextApp: NextServer = createNextServer({
   port: 8080,
 });
 
+interface RoutesManifestRewrite {
+  source: string;
+  destination: string;
+  regex: string;
+  has?: unknown[];
+  missing?: unknown[];
+}
+
+interface RoutesManifest {
+  rewrites:
+    | RoutesManifestRewrite[]
+    | {
+        beforeFiles?: RoutesManifestRewrite[];
+        afterFiles?: RoutesManifestRewrite[];
+        fallback?: RoutesManifestRewrite[];
+      };
+}
+
+// Cache for external rewrites
+let externalRewritesCache: RoutesManifestRewrite[] | null = null;
+
+/**
+ * Load and cache external rewrites from the routes manifest.
+ * External rewrites are those with http:// or https:// destinations.
+ */
+async function getExternalRewrites(): Promise<RoutesManifestRewrite[]> {
+  if (externalRewritesCache !== null) {
+    return externalRewritesCache;
+  }
+
+  try {
+    const manifestPath = join(process.cwd(), ".next", "routes-manifest.json");
+    const manifestContent = await readFile(manifestPath, "utf-8");
+    const manifest: RoutesManifest = JSON.parse(manifestContent);
+
+    let allRewrites: RoutesManifestRewrite[] = [];
+    if (Array.isArray(manifest.rewrites)) {
+      allRewrites = manifest.rewrites;
+    } else if (manifest.rewrites) {
+      allRewrites = [
+        ...(manifest.rewrites.beforeFiles || []),
+        ...(manifest.rewrites.afterFiles || []),
+        ...(manifest.rewrites.fallback || []),
+      ];
+    }
+
+    // Filter to only external URL rewrites
+    externalRewritesCache = allRewrites.filter(
+      (rewrite) =>
+        rewrite.destination.startsWith("http://") ||
+        rewrite.destination.startsWith("https://")
+    );
+
+    return externalRewritesCache;
+  } catch {
+    externalRewritesCache = [];
+    return externalRewritesCache;
+  }
+}
+
+/**
+ * Handle external URL rewrites by proxying directly.
+ * This is needed because Next.js's internal http-proxy doesn't work
+ * properly in Cloud Functions due to socket handling issues.
+ *
+ * Returns true if the request was handled, false otherwise.
+ */
+async function handleExternalRewrite(
+  req: Request,
+  res: Response
+): Promise<boolean> {
+  const externalRewrites = await getExternalRewrites();
+  if (externalRewrites.length === 0) {
+    return false;
+  }
+
+  const url = req.url || "/";
+
+  for (const rewrite of externalRewrites) {
+    const regex = new RegExp(rewrite.regex);
+    const match = url.match(regex);
+
+    if (match) {
+      try {
+        // Build the destination URL by replacing path parameters
+        let destination = rewrite.destination;
+
+        // Handle :param* style path parameters using capture groups
+        if (match.length > 1) {
+          // Replace :path* or similar with the captured group
+          const sourceParams = rewrite.source.match(/:([^/]+)\*?/g) || [];
+          for (let i = 0; i < sourceParams.length && i + 1 < match.length; i++) {
+            const capturedValue = match[i + 1] || "";
+            destination = destination.replace(sourceParams[i], capturedValue);
+          }
+        }
+
+        // Make the proxy request
+        const headers: Record<string, string> = {};
+        for (const [key, value] of Object.entries(req.headers)) {
+          if (key.toLowerCase() !== "host" && typeof value === "string") {
+            headers[key] = value;
+          }
+        }
+        headers["x-forwarded-host"] = req.headers.host || "";
+
+        const fetchOptions: RequestInit = {
+          method: req.method,
+          headers,
+          redirect: "manual",
+        };
+
+        // Add body for non-GET/HEAD requests
+        if (
+          req.method &&
+          !["GET", "HEAD"].includes(req.method) &&
+          req.rawBody
+        ) {
+          // Convert Buffer to Uint8Array for fetch compatibility
+          fetchOptions.body = new Uint8Array(req.rawBody);
+        }
+
+        const proxyRes = await fetch(destination, fetchOptions);
+
+        // Copy response headers, excluding problematic ones
+        // - transfer-encoding: handled by the framework
+        // - content-encoding: fetch auto-decompresses
+        // - content-length: may change after decompression
+        const skipHeaders = [
+          "transfer-encoding",
+          "content-encoding",
+          "content-length",
+        ];
+        for (const [key, value] of proxyRes.headers.entries()) {
+          if (!skipHeaders.includes(key.toLowerCase())) {
+            res.setHeader(key, value);
+          }
+        }
+
+        res.status(proxyRes.status);
+
+        // Get response as buffer and send
+        const buffer = Buffer.from(await proxyRes.arrayBuffer());
+        res.send(buffer);
+
+        return true;
+      } catch (err) {
+        console.error("External rewrite proxy error:", err);
+        res.status(502).send("Bad Gateway: Failed to proxy to external URL");
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
 export const handle = async (req: Request, res: Response): Promise<void> => {
+  // Handle external URL rewrites first, before Next.js processes the request.
+  // This is necessary because Next.js's internal http-proxy doesn't work
+  // properly in Cloud Functions due to socket handling issues.
+  const handled = await handleExternalRewrite(req, res);
+  if (handled) {
+    return;
+  }
+
   await nextApp.prepare();
   const parsedUrl = parse(req.url, true);
   const incomingMessage = incomingMessageFromExpress(req);

--- a/packages/firebase-frameworks/src/next.js/index.ts
+++ b/packages/firebase-frameworks/src/next.js/index.ts
@@ -71,7 +71,8 @@ async function getExternalRewrites(): Promise<RoutesManifestRewrite[]> {
     );
 
     return externalRewritesCache;
-  } catch {
+  } catch (err) {
+    console.error("Failed to load or parse routes-manifest.json:", err);
     externalRewritesCache = [];
     return externalRewritesCache;
   }

--- a/packages/firebase-frameworks/src/next.js/index.ts
+++ b/packages/firebase-frameworks/src/next.js/index.ts
@@ -66,8 +66,7 @@ async function getExternalRewrites(): Promise<RoutesManifestRewrite[]> {
     // Filter to only external URL rewrites
     externalRewritesCache = allRewrites.filter(
       (rewrite) =>
-        rewrite.destination.startsWith("http://") ||
-        rewrite.destination.startsWith("https://")
+        rewrite.destination.startsWith("http://") || rewrite.destination.startsWith("https://"),
     );
 
     return externalRewritesCache;
@@ -85,10 +84,7 @@ async function getExternalRewrites(): Promise<RoutesManifestRewrite[]> {
  *
  * Returns true if the request was handled, false otherwise.
  */
-async function handleExternalRewrite(
-  req: Request,
-  res: Response
-): Promise<boolean> {
+async function handleExternalRewrite(req: Request, res: Response): Promise<boolean> {
   const externalRewrites = await getExternalRewrites();
   if (externalRewrites.length === 0) {
     return false;
@@ -131,13 +127,9 @@ async function handleExternalRewrite(
         };
 
         // Add body for non-GET/HEAD requests
-        if (
-          req.method &&
-          !["GET", "HEAD"].includes(req.method) &&
-          req.rawBody
-        ) {
-          // Convert Buffer to Uint8Array for fetch compatibility
-          fetchOptions.body = new Uint8Array(req.rawBody);
+        if (req.method && !["GET", "HEAD"].includes(req.method) && req.rawBody) {
+          // Node.js fetch accepts Buffer directly at runtime
+          fetchOptions.body = req.rawBody as unknown as BodyInit;
         }
 
         const proxyRes = await fetch(destination, fetchOptions);
@@ -146,13 +138,9 @@ async function handleExternalRewrite(
         // - transfer-encoding: handled by the framework
         // - content-encoding: fetch auto-decompresses
         // - content-length: may change after decompression
-        const skipHeaders = [
-          "transfer-encoding",
-          "content-encoding",
-          "content-length",
-        ];
+        const skipHeaders = new Set(["transfer-encoding", "content-encoding", "content-length"]);
         for (const [key, value] of proxyRes.headers.entries()) {
-          if (!skipHeaders.includes(key.toLowerCase())) {
+          if (!skipHeaders.has(key.toLowerCase())) {
             res.setHeader(key, value);
           }
         }


### PR DESCRIPTION
## Description

### Problem

Next.js external URL rewrites (rewrites to `http://` or `https://` destinations) fail with **504 Gateway Timeout** when deployed to Firebase Hosting.

**Related issues:**
- https://github.com/firebase/firebase-tools/issues/8968

**Example configuration that fails:**
```typescript
// next.config.ts
async rewrites() {
  return [
    {
      source: '/proxy/:path*',
      destination: 'https://api.example.com/:path*',
    },
  ];
}
```

### Root Cause

In `incomingMessageFromExpress()`, a new `Socket()` is created which is **disconnected** (has no network connection):

```typescript
const socket = new Socket();  // Disconnected socket
const incomingMessage = new IncomingMessage(socket);
```

When Next.js handles external rewrites, it uses `http-proxy` internally, which relies on the socket to pipe the response back to the client. With a disconnected socket, the response cannot be delivered, causing the request to hang until Cloud Functions times out (504).

### Solution

Intercept external URL rewrites **before** they reach Next.js's internal `http-proxy`. The new `handleExternalRewrite()` function:

1. Reads `routes-manifest.json` to identify external rewrites
2. Matches incoming requests against rewrite patterns
3. Proxies directly using `fetch()` (which doesn't depend on socket state)
4. Handles response headers properly (skipping `content-encoding`, `transfer-encoding`, `content-length` to avoid decompression issues)
5. Returns the response via Express's `res.send()`

This bypasses the broken code path entirely while maintaining full compatibility with Next.js rewrite semantics.

### Changes

- **`src/next.js/index.ts`**: Added `handleExternalRewrite()` function and external rewrite interception in the `handle()` export

### Testing

1. Create a Next.js app with external rewrites:
```typescript
// next.config.ts
async rewrites() {
  return [
    {
      source: '/proxy/:path*',
      destination: 'https://jsonplaceholder.typicode.com/:path*',
    },
  ];
}
```

2. Deploy to Firebase Hosting with `firebase deploy`

3. Test the proxy endpoint:
```bash
curl https://your-site.web.app/proxy/posts/1
```

**Expected:** Returns JSON from jsonplaceholder API  
**Before fix:** 504 Gateway Timeout after ~60 seconds

---