### PR TITLE
feat(adapter-angular): validate required environment variables before build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25665,7 +25665,7 @@
       }
     },
     "packages/@apphosting/build": {
-      "version": "0.1.7",
+      "version": "0.1.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@apphosting/common": "*",

--- a/packages/@apphosting/adapter-angular/src/bin/build.ts
+++ b/packages/@apphosting/adapter-angular/src/bin/build.ts
@@ -1,12 +1,16 @@
-#! /usr/bin/env node
+#!/usr/bin/env node
 import {
   generateBuildOutput,
   checkBuildConditions,
   validateOutputDirectory,
   parseOutputBundleOptions,
   metaFrameworkOutputBundleExists,
+  validateEnvironment,
 } from "../utils.js";
 import { getBuildOptions, runBuild } from "@apphosting/common";
+
+// Validate environment variables before executing the build
+validateEnvironment();
 
 const opts = getBuildOptions();
 

--- a/packages/@apphosting/adapter-angular/src/utils.spec.ts
+++ b/packages/@apphosting/adapter-angular/src/utils.spec.ts
@@ -67,3 +67,62 @@ describe("metaFrameworkOutputBundleExists", () => {
     assert(!metaFrameworkOutputBundleExists());
   });
 });
+
+describe("validateEnvironment", () => {
+  let originalEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    originalEnv = { ...process.env };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("should succeed if environment variables are correctly set", async () => {
+    const { validateEnvironment } = await importUtils;
+    process.env.NG_ALLOWED_HOSTS = "example.com";
+    process.env.NG_TRUST_PROXY_HEADERS = "X-Forwarded-Host";
+    assert.doesNotThrow(() => validateEnvironment());
+  });
+
+  it("should throw an error if NG_ALLOWED_HOSTS is not set", async () => {
+    const { validateEnvironment } = await importUtils;
+    delete process.env.NG_ALLOWED_HOSTS;
+    process.env.NG_TRUST_PROXY_HEADERS = "X-Forwarded-Host";
+    assert.throws(
+      () => validateEnvironment(),
+      /NG_ALLOWED_HOSTS environment variable must be set and not empty/,
+    );
+  });
+
+  it("should throw an error if NG_ALLOWED_HOSTS is empty", async () => {
+    const { validateEnvironment } = await importUtils;
+    process.env.NG_ALLOWED_HOSTS = "   ";
+    process.env.NG_TRUST_PROXY_HEADERS = "X-Forwarded-Host";
+    assert.throws(
+      () => validateEnvironment(),
+      /NG_ALLOWED_HOSTS environment variable must be set and not empty/,
+    );
+  });
+
+  it("should throw an error if NG_TRUST_PROXY_HEADERS is not set", async () => {
+    const { validateEnvironment } = await importUtils;
+    process.env.NG_ALLOWED_HOSTS = "example.com";
+    delete process.env.NG_TRUST_PROXY_HEADERS;
+    assert.throws(
+      () => validateEnvironment(),
+      /NG_TRUST_PROXY_HEADERS environment variable must be set to 'X-Forwarded-Host'/,
+    );
+  });
+
+  it("should throw an error if NG_TRUST_PROXY_HEADERS is not set correctly", async () => {
+    const { validateEnvironment } = await importUtils;
+    process.env.NG_ALLOWED_HOSTS = "example.com";
+    process.env.NG_TRUST_PROXY_HEADERS = "true";
+    assert.throws(
+      () => validateEnvironment(),
+      /NG_TRUST_PROXY_HEADERS environment variable must be set to 'X-Forwarded-Host'/,
+    );
+  });
+});

--- a/packages/@apphosting/adapter-angular/src/utils.ts
+++ b/packages/@apphosting/adapter-angular/src/utils.ts
@@ -298,3 +298,20 @@ export const metaFrameworkOutputBundleExists = () => {
   }
   return false;
 };
+
+/**
+ * Validates the required environment variables for the build.
+ */
+export function validateEnvironment(): void {
+  const allowedHosts = process.env.NG_ALLOWED_HOSTS;
+  if (!allowedHosts || allowedHosts.trim() === "") {
+    throw new Error("NG_ALLOWED_HOSTS environment variable must be set and not empty.");
+  }
+
+  const trustProxyHeaders = process.env.NG_TRUST_PROXY_HEADERS;
+  if (!trustProxyHeaders || trustProxyHeaders !== "X-Forwarded-Host") {
+    throw new Error(
+      "NG_TRUST_PROXY_HEADERS environment variable must be set to 'X-Forwarded-Host'.",
+    );
+  }
+}

--- a/packages/@apphosting/build/package.json
+++ b/packages/@apphosting/build/package.json
@@ -1,8 +1,8 @@
 {
     "name": "@apphosting/build",
-    "version": "0.1.7",
+    "version": "0.1.8",
     "main": "dist/index.js",
-    "description": "Experimental addon to the Firebase CLI to add web framework support",
+    "description": "Experimental addon to the Firebase CLI to run local builds",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/FirebaseExtended/firebase-framework-tools.git"


### PR DESCRIPTION
### Description
This PR introduces validation for crucial environment variables in the Angular adapter before the build process execution:
- `NG_ALLOWED_HOSTS`: Must be set and not empty/whitespace-only.
- `NG_TRUST_PROXY_HEADERS`: Must be set specifically to `'X-Forwarded-Host'`.

### Changes
- `packages/@apphosting/adapter-angular/src/bin/build.ts`: Added environment validation via `validateEnvironment()` before initializing the build.
- `packages/@apphosting/adapter-angular/src/utils.ts`: Implemented the `validateEnvironment` helper function checking process environment variables.
- `packages/@apphosting/adapter-angular/src/utils.spec.ts`: Added robust unit tests covering positive validation cases and negative/failure cases (missing/invalid variables).

### Verification
- Added comprehensive unit tests verifying both successful and failing validation cases.