### PR TITLE
fix: resolve symlinks when checking entrypoint in isMain

### DIFF
--- a/packages/@apphosting/adapter-angular/src/utils.ts
+++ b/packages/@apphosting/adapter-angular/src/utils.ts
@@ -280,7 +280,11 @@ export async function validateOutputDirectory(
 export const isMain = (meta: ImportMeta) => {
   if (!meta) return false;
   if (!process.argv[1]) return false;
-  return process.argv[1] === fileURLToPath(meta.url);
+  try {
+    return fsExtra.realpathSync(process.argv[1]) === fileURLToPath(meta.url);
+  } catch {
+    return false;
+  }
 };
 
 export const metaFrameworkOutputBundleExists = () => {

--- a/packages/@apphosting/adapter-nextjs/src/utils.ts
+++ b/packages/@apphosting/adapter-nextjs/src/utils.ts
@@ -99,7 +99,11 @@ export async function writeRouteManifest(
 export const isMain = (meta: ImportMeta): boolean => {
   if (!meta) return false;
   if (!process.argv[1]) return false;
-  return process.argv[1] === fileURLToPath(meta.url);
+  try {
+    return fsExtra.realpathSync(process.argv[1]) === fileURLToPath(meta.url);
+  } catch {
+    return false;
+  }
 };
 
 /**


### PR DESCRIPTION
Fixes a bug where symlinked binaries in `node_modules/.bin` evaluate to false in isMain checks (because `process.argv[1]` is a symlink path), preventing the build script from executing.